### PR TITLE
refactor(google_play.py): move screen size setting after emulator boot

### DIFF
--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -331,10 +331,6 @@ class GooglePlayEmulatorController(BaseEmulatorController):
         while self._is_emulator_running():
             self.stop()
 
-        for i in range(3):
-            print(f'Setting adb screen size to {self.expected_dims}')
-            self._set_screen_size(*self.expected_dims)
-
         # boot emulator
         self.logger.change_status("Starting Google Play emulator...")
         print("Starting emulator...")
@@ -358,7 +354,11 @@ class GooglePlayEmulatorController(BaseEmulatorController):
 
         time.sleep(10)
 
-        
+        self.logger.change_status(f"Setting emulator screen size to {self.expected_dims}...")
+        for i in range(3):
+            print(f'Setting adb screen size to {self.expected_dims}')
+            self._set_screen_size(*self.expected_dims)
+            time.sleep(1)
 
         # validate image size
         self.logger.change_status("Validating Google Play emulator screen dimensions...")


### PR DESCRIPTION
The screen size setting is moved after the emulator boot to ensure the emulator is fully started before attempting to set the screen size. This improves reliability.