### PR TITLE
Add discord webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ _Join our [Discord server](https://discord.gg/nqKRkyq2UU) for support, updates, 
 - **Render Mode Selection** - Choose between OpenGL, DirectX, and Vulkan rendering
 - **Real-time Statistics** - Track wins, losses, chests opened, and more
 - **Performance Monitoring** - Monitor bot runtime, failures, and account switches
+- **Discord Webhook Notifications** - Receive real-time notifications about bot status, battle results, and errors directly in Discord
 
 ## 🚀 Setup Instructions
 
@@ -81,6 +82,43 @@ _Join our [Discord server](https://discord.gg/nqKRkyq2UU) for support, updates, 
 - **Language Setting** - Ensure Clash Royale is set to English for optimal bot performance
 - **Tutorial Completion** - The tutorial must be completed manually before starting the bot
 - **Account Setup** - Sign in with SuperCell ID or create a new account as needed
+
+## 📢 Discord Webhook Notifications
+
+Receive real-time notifications about your bot's activity directly in Discord! This feature allows you to monitor your bot remotely, getting notified about important events like bot starts, stops, battle results, and errors.
+
+### Setting Up Discord Webhooks
+
+1. **Create a Discord Webhook**
+   - Open your Discord server
+   - Go to **Server Settings** → **Integrations** → **Webhooks**
+   - Click **New Webhook** or **Create Webhook**
+   - Name your webhook (e.g., "PyClashBot Notifications")
+   - Copy the webhook URL (starts with `https://discord.com/api/webhooks/`)
+
+2. **Configure in py-clash-bot**
+   - Open the bot application
+   - Navigate to the **Misc** tab
+   - Find the **Discord Webhook** section
+   - Paste your webhook URL into the **Webhook URL** field
+   - The webhook URL is automatically saved in your settings
+
+### What You'll Receive
+
+The bot will send notifications for:
+
+- **🤖 Bot Started** - When the bot begins automation (includes current state)
+- **🛑 Bot Stopped** - When the bot stops (includes final statistics: wins, losses, win rate, runtime, failures)
+- **🎉 Battle Won** - When you win a battle (includes battle type and win rate)
+- **😔 Battle Lost** - When you lose a battle (includes battle type and win rate)
+- **⚠️ Bot Error** - When an error occurs (includes error message and context)
+
+### Notes
+
+- **Optional Feature** - Discord webhooks are completely optional. Leave the field empty to disable notifications.
+- **Privacy** - Webhook URLs are stored locally in your user settings and are not shared with anyone.
+- **Non-Blocking** - Webhook notifications are sent asynchronously and won't slow down or interfere with bot operation.
+- **Error Handling** - If a webhook fails to send (e.g., invalid URL or network issues), the bot will continue operating normally without disruption.
 
 ## 🔧 Emulator Debugging
 

--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -72,6 +72,11 @@ def make_job_dictionary(values: dict[str, Any]) -> dict[str, Any]:
     else:
         job_dictionary["emulator"] = "MEmu"
 
+    # Discord webhook URL
+    webhook_url = values.get(UIField.DISCORD_WEBHOOK_URL.value)
+    if webhook_url:
+        job_dictionary["discord_webhook_url"] = str(webhook_url).strip()
+
     return job_dictionary
 
 
@@ -108,6 +113,13 @@ def start_button_event(logger: Logger, ui: PyClashBotUI, values: dict[str, Any])
     logger.change_status("Starting the bot!")
     save_current_settings(values)
     logger.log_job_dictionary(job_dictionary)
+
+    # Set Discord webhook URL if provided
+    webhook_url = job_dictionary.get("discord_webhook_url")
+    if webhook_url:
+        logger.set_discord_webhook(webhook_url)
+    else:
+        logger.set_discord_webhook(None)
 
     ui.set_running_state(True)
     ui.notebook.select(ui.stats_tab)

--- a/pyclashbot/bot/worker.py
+++ b/pyclashbot/bot/worker.py
@@ -123,3 +123,7 @@ class WorkerThread(PausableThread):
             return
         except Exception as err:
             self.logger.error(str(err))
+        finally:
+            # Send notification when bot stops naturally
+            if self.logger.discord_webhook:
+                self.logger.change_status("Bot stopped")

--- a/pyclashbot/interface/config.py
+++ b/pyclashbot/interface/config.py
@@ -141,7 +141,7 @@ USER_CONFIG_KEYS = (
     [job.key.value for job in JOBS]
     + [radio.key.value for radio in MEMU_SETTINGS + BLUESTACKS_SETTINGS + EMULATOR_CHOICE]
     + [combo.key.value for combo in GOOGLE_PLAY_SETTINGS]
-    + [UIField.THEME_NAME.value, UIField.RECORD_FIGHTS_TOGGLE.value]  # Data settings
+    + [UIField.THEME_NAME.value, UIField.RECORD_FIGHTS_TOGGLE.value, UIField.DISCORD_WEBHOOK_URL.value]  # Data settings
     + [
         UIField.DECK_NUMBER_SELECTION.value,
         UIField.MAX_DECK_SELECTION.value,

--- a/pyclashbot/interface/enums.py
+++ b/pyclashbot/interface/enums.py
@@ -55,6 +55,7 @@ class UIField(StrEnum):
     GP_EGL = "gp_egl"
     GP_BACKEND = "gp_backend"
     GP_WSI = "gp_wsi"
+    DISCORD_WEBHOOK_URL = "discord_webhook_url"
 
 
 BATTLE_STAT_LABELS: dict[StatField, str] = {

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -104,6 +104,7 @@ class PyClashBotUI(ttk.Window):
         for field, var in self.gp_vars.items():
             values[field.value] = var.get()
         values[UIField.THEME_NAME.value] = self.theme_var.get() or self.DEFAULT_THEME
+        values[UIField.DISCORD_WEBHOOK_URL.value] = self.discord_webhook_var.get()
         return values
 
     def set_all_values(self, values: dict[str, object]) -> None:
@@ -146,6 +147,9 @@ class PyClashBotUI(ttk.Window):
             for field, var in self.gp_vars.items():
                 if values.get(field.value):
                     var.set(str(values[field.value]))
+
+            if UIField.DISCORD_WEBHOOK_URL.value in values:
+                self.discord_webhook_var.set(str(values[UIField.DISCORD_WEBHOOK_URL.value]))
 
             self._update_google_play_comboboxes()
             self._show_emulator_settings()
@@ -589,6 +593,29 @@ class PyClashBotUI(ttk.Window):
             command=self._on_open_logs_clicked,
         )
         self.open_logs_btn.pack(fill="x", pady=(6, 0))
+
+        ttk.Separator(self.misc_tab, orient="horizontal").pack(fill="x", padx=10, pady=(6, 0))
+        webhook_frame = ttk.Labelframe(self.misc_tab, text="Discord Webhook", padding=10)
+        webhook_frame.pack(fill="x", padx=10, pady=10)
+
+        ttk.Label(webhook_frame, text="Webhook URL:").pack(anchor="w", pady=(0, 4))
+        self.discord_webhook_var = ttk.StringVar(value="")
+        self.discord_webhook_entry = ttk.Entry(
+            webhook_frame,
+            textvariable=self.discord_webhook_var,
+            width=50,
+        )
+        self.discord_webhook_entry.pack(anchor="w", fill="x")
+        self.discord_webhook_entry.bind("<KeyRelease>", self._notify_config_change)
+        self._trace_variable(self.discord_webhook_var)
+        self._register_config_widget(UIField.DISCORD_WEBHOOK_URL.value, self.discord_webhook_entry)
+
+        ttk.Label(
+            webhook_frame,
+            text="Optional: Enter Discord webhook URL to receive notifications",
+            font=("TkDefaultFont", 8),
+            foreground="gray",
+        ).pack(anchor="w", pady=(4, 0))
 
     def _register_config_widget(self, key: str, widget: tk.Widget) -> None:
         self._config_widgets[key] = widget

--- a/pyclashbot/utils/discord_webhook.py
+++ b/pyclashbot/utils/discord_webhook.py
@@ -1,0 +1,264 @@
+"""Discord webhook integration for sending notifications."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import requests
+
+
+class DiscordWebhook:
+    """Discord webhook client for sending notifications."""
+
+    def __init__(self, webhook_url: str | None = None) -> None:
+        """Initialize Discord webhook client.
+
+        Args:
+        ----
+            webhook_url: Discord webhook URL. If None, webhook is disabled.
+        """
+        self.webhook_url = webhook_url
+        self.enabled = webhook_url is not None and webhook_url.strip() != ""
+
+    def _send_webhook(self, payload: dict[str, Any], timeout: int = 5) -> bool:
+        """Send webhook payload to Discord.
+
+        Args:
+        ----
+            payload: Discord webhook payload
+            timeout: Request timeout in seconds
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        if not self.enabled or self.webhook_url is None:
+            return False
+
+        try:
+            response = requests.post(self.webhook_url, json=payload, timeout=timeout)
+            response.raise_for_status()
+            return True
+        except Exception:
+            # Silently fail to avoid disrupting bot operation
+            return False
+
+    def send(self, content: str | None = None, embeds: list[dict[str, Any]] | None = None) -> bool:
+        """Send a message to Discord webhook.
+
+        Args:
+        ----
+            content: Message content (plain text)
+            embeds: List of embed dictionaries
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        if not self.enabled:
+            return False
+
+        payload: dict[str, Any] = {}
+        if content:
+            payload["content"] = content
+        if embeds:
+            payload["embeds"] = embeds
+
+        if not payload:
+            return False
+
+        # Send in a separate thread to avoid blocking
+        thread = threading.Thread(target=self._send_webhook, args=(payload,), daemon=True)
+        thread.start()
+        return True
+
+    def send_embed(
+        self,
+        title: str,
+        description: str | None = None,
+        color: int | None = None,
+        fields: list[dict[str, Any]] | None = None,
+        footer: dict[str, Any] | None = None,
+    ) -> bool:
+        """Send an embed message to Discord webhook.
+
+        Args:
+        ----
+            title: Embed title
+            description: Embed description
+            color: Embed color (integer, e.g., 0x00ff00 for green)
+            fields: List of field dictionaries with 'name' and 'value' keys
+            footer: Footer dictionary with 'text' key
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        embed: dict[str, Any] = {"title": title}
+        if description:
+            embed["description"] = description
+        if color is not None:
+            embed["color"] = color
+        if fields:
+            embed["fields"] = fields
+        if footer:
+            embed["footer"] = footer
+
+        return self.send(embeds=[embed])
+
+    def send_bot_started(self, runtime_info: dict[str, Any] | None = None) -> bool:
+        """Send notification that bot has started.
+
+        Args:
+        ----
+            runtime_info: Optional dictionary with runtime information
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        fields = []
+        if runtime_info:
+            for key, value in runtime_info.items():
+                if value is not None:
+                    fields.append({"name": key.replace("_", " ").title(), "value": str(value), "inline": True})
+
+        return self.send_embed(
+            title="🤖 Bot Started",
+            description="PyClashBot has started successfully",
+            color=0x00FF00,  # Green
+            fields=fields if fields else None,
+        )
+
+    def send_bot_stopped(self, stats: dict[str, Any] | None = None) -> bool:
+        """Send notification that bot has stopped.
+
+        Args:
+        ----
+            stats: Optional dictionary with bot statistics
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        fields = []
+        if stats:
+            important_stats = [
+                ("wins", "Wins"),
+                ("losses", "Losses"),
+                ("winrate", "Win Rate"),
+                ("time_since_start", "Runtime"),
+                ("restarts_after_failure", "Failures"),
+            ]
+            for key, label in important_stats:
+                if key in stats and stats[key] is not None:
+                    fields.append({"name": label, "value": str(stats[key]), "inline": True})
+
+        return self.send_embed(
+            title="🛑 Bot Stopped",
+            description="PyClashBot has stopped",
+            color=0xFFA500,  # Orange
+            fields=fields if fields else None,
+        )
+
+    def send_battle_result(self, won: bool, battle_type: str, stats: dict[str, Any] | None = None) -> bool:
+        """Send notification about battle result.
+
+        Args:
+        ----
+            won: True if battle was won, False if lost
+            battle_type: Type of battle (e.g., "1v1", "2v2")
+            stats: Optional dictionary with battle statistics
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        emoji = "🎉" if won else "😔"
+        title = f"{emoji} Battle {'Won' if won else 'Lost'}"
+        description = f"Battle result: {battle_type}"
+        color = 0x00FF00 if won else 0xFF0000  # Green for win, red for loss
+
+        fields = []
+        if stats:
+            for key, value in stats.items():
+                if value is not None:
+                    fields.append({"name": key.replace("_", " ").title(), "value": str(value), "inline": True})
+
+        return self.send_embed(title=title, description=description, color=color, fields=fields if fields else None)
+
+    def send_error(self, error_message: str, context: str | None = None) -> bool:
+        """Send notification about an error.
+
+        Args:
+        ----
+            error_message: Error message
+            context: Optional context information
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        fields = []
+        if context:
+            fields.append({"name": "Context", "value": context, "inline": False})
+
+        description = error_message[:2000] if len(error_message) > 2000 else error_message
+
+        return self.send_embed(
+            title="⚠️ Bot Error",
+            description=description,
+            color=0xFF0000,  # Red
+            fields=fields if fields else None,
+        )
+
+    def send_status_update(self, status: str, details: dict[str, Any] | None = None) -> bool:
+        """Send a status update notification.
+
+        Args:
+        ----
+            status: Status message
+            details: Optional dictionary with additional details
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        fields = []
+        if details:
+            for key, value in details.items():
+                if value is not None:
+                    fields.append({"name": key.replace("_", " ").title(), "value": str(value), "inline": True})
+
+        return self.send_embed(
+            title="ℹ️ Status Update",
+            description=status,
+            color=0x0099FF,  # Blue
+            fields=fields if fields else None,
+        )
+
+    def send_statistics(self, stats: dict[str, Any], title: str = "📊 Bot Statistics") -> bool:
+        """Send bot statistics as an embed.
+
+        Args:
+        ----
+            stats: Dictionary with statistics
+            title: Optional title for the embed
+
+        Returns:
+        -------
+            True if successful, False otherwise
+        """
+        fields = []
+        for key, value in stats.items():
+            if value is not None:
+                fields.append({"name": key.replace("_", " ").title(), "value": str(value), "inline": True})
+
+        return self.send_embed(
+            title=title,
+            description="Current bot statistics",
+            color=0x0099FF,  # Blue
+            fields=fields if fields else None,
+        )
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pygetwindow (>=0.0.9,<0.0.10)",
     "pillow (>=11.3.0,<12.0.0)",
     "ttkbootstrap>=1.12.1,<1.13",
+    "requests>=2.32.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
   ## Description
   Adds Discord webhook support to py-clash-bot, allowing users to receive real-time notifications about bot activity directly in Discord.

   ## Changes Made
   - Added `DiscordWebhook` utility class for sending notifications
   - Integrated webhook notifications into logger for key events:
     - Bot started/stopped
     - Battle wins/losses  
     - Error notifications
   - Added Discord webhook URL field to UI (Misc tab)
   - Updated dependencies to include `requests` package
   - Added comprehensive documentation in README.md

   ## Features
   - Real-time Discord notifications for bot events
   - Optional feature (can be disabled by leaving field empty)
   - Non-blocking async notifications
   - Graceful error handling (bot continues if webhook fails)
   - Privacy-focused (webhook URLs stored locally only)

   ## Testing
   - [x] Tested Discord webhook notifications work correctly
   - [x] Verified bot continues operating if webhook fails
   - [x] Confirmed webhook URL is saved and persists between sessions
   - [x] Tested all notification types (start, stop, wins, losses, errors)

   ## Documentation
   - [x] Updated README.md with setup instructions
   - [x] Added examples and usage notes
   - [x] Code includes comprehensive docstrings