### PR TITLE
feat: add deck screenshot capture with webhook support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ dist
 __version__
 __pycache__
 recordings
-.claude/
-.claude/settings.local.json
+.env

--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -7,6 +7,7 @@ import subprocess
 from os.path import expandvars, join
 from typing import TYPE_CHECKING, Any
 
+from pyclashbot.bot.deck_screenshot import DECK_SCREENSHOT_DIR
 from pyclashbot.bot.worker import WorkerThread
 from pyclashbot.emulators.adb import AdbController
 from pyclashbot.interface.enums import PRIMARY_JOB_TOGGLES, UIField
@@ -48,6 +49,7 @@ def make_job_dictionary(values: dict[str, Any]) -> dict[str, Any]:
         UIField.RANDOM_PLAYS_USER_TOGGLE.value: as_bool(UIField.RANDOM_PLAYS_USER_TOGGLE),
         UIField.DISABLE_WIN_TRACK_TOGGLE.value: as_bool(UIField.DISABLE_WIN_TRACK_TOGGLE),
         UIField.RECORD_FIGHTS_TOGGLE.value: as_bool(UIField.RECORD_FIGHTS_TOGGLE),
+        UIField.CAPTURE_DECK_SCREENSHOTS_TOGGLE.value: as_bool(UIField.CAPTURE_DECK_SCREENSHOTS_TOGGLE),
     }
 
     job_dictionary["upgrade_user_toggle"] = as_bool(UIField.CARD_UPGRADE_USER_TOGGLE)
@@ -191,6 +193,17 @@ def open_logs_folder() -> None:
         subprocess.Popen(["xdg-open", folder_path])
 
 
+def open_deck_screenshots_folder() -> None:
+    folder_path = DECK_SCREENSHOT_DIR
+    os.makedirs(folder_path, exist_ok=True)
+    try:
+        os.startfile(folder_path)
+    except AttributeError:
+        import subprocess
+
+        subprocess.Popen(["xdg-open", folder_path])
+
+
 class BotApplication:
     """Main application class for the ttkbootstrap GUI."""
 
@@ -201,6 +214,7 @@ class BotApplication:
         self.ui.register_config_callback(self._on_config_change)
         self.ui.register_open_recordings_callback(self._on_open_recordings_clicked)
         self.ui.register_open_logs_callback(self._on_open_logs_clicked)
+        self.ui.register_open_deck_screenshots_callback(self._on_open_deck_screenshots_clicked)
         self.ui.protocol("WM_DELETE_WINDOW", self._on_close)
         self.ui.adb_refresh_btn.configure(command=self._on_adb_refresh)
         self.ui.adb_connect_btn.configure(command=self._on_adb_connect)
@@ -287,6 +301,9 @@ class BotApplication:
 
     def _on_open_logs_clicked(self) -> None:
         open_logs_folder()
+
+    def _on_open_deck_screenshots_clicked(self) -> None:
+        open_deck_screenshots_folder()
 
     def _on_close(self) -> None:
         self._closing = True

--- a/pyclashbot/bot/deck_screenshot.py
+++ b/pyclashbot/bot/deck_screenshot.py
@@ -1,0 +1,114 @@
+"""Deck screenshot capture functionality during battle."""
+
+import os
+import time
+from os.path import expandvars, join
+
+import cv2
+
+from pyclashbot.bot.nav import check_if_in_battle
+from pyclashbot.utils.logger import Logger
+from pyclashbot.utils.webhook import DECK_SCREENSHOT_WEBHOOK_URL, send_deck_screenshot_webhook
+
+# Deck screenshot folder
+DECK_SCREENSHOT_DIR = join(expandvars("%localappdata%"), "programs", "py-clash-bot", "deck_screenshots")
+
+# Region for deck/hand during battle (x1, y1, x2, y2)
+# Captures the bottom area where cards are shown during battle
+# Hand cards are at y ~561-563, so we capture from y=520 to bottom (633)
+BATTLE_DECK_REGION = (80, 520, 400, 633)
+
+
+def ensure_deck_folder_exists() -> None:
+    """Ensure the deck screenshots folder exists."""
+    os.makedirs(DECK_SCREENSHOT_DIR, exist_ok=True)
+
+
+def capture_deck_screenshot(emulator, logger: Logger) -> bool:
+    """Capture a screenshot of the deck/hand during battle.
+
+    Args:
+        emulator: The emulator controller
+        logger: Logger instance
+
+    Returns:
+        True if screenshot was captured, False otherwise
+    """
+    try:
+        # Ensure folder exists before attempting to save
+        ensure_deck_folder_exists()
+
+        # Check if we're in battle
+        if not check_if_in_battle(emulator):
+            # Don't log every time we're not in battle to avoid spam
+            return False
+
+        # Take screenshot (returns BGR format from emulator)
+        screenshot = emulator.screenshot()
+        if screenshot is None:
+            logger.log("Failed to capture screenshot: emulator.screenshot() returned None")
+            return False
+
+        # Validate screenshot dimensions
+        if screenshot.size == 0:
+            logger.log("Failed to capture screenshot: screenshot is empty")
+            return False
+
+        height, width = screenshot.shape[:2]
+
+        # Crop to deck/hand region during battle (x1, y1, x2, y2)
+        x1, y1, x2, y2 = BATTLE_DECK_REGION
+
+        # Validate crop region is within screenshot bounds
+        if x1 < 0 or y1 < 0 or x2 > width or y2 > height:
+            logger.log(
+                f"Crop region ({x1}, {y1}, {x2}, {y2}) exceeds screenshot bounds ({width}x{height})"
+            )
+            return False
+
+        if x1 >= x2 or y1 >= y2:
+            logger.log(f"Invalid crop region: ({x1}, {y1}, {x2}, {y2})")
+            return False
+
+        deck_crop = screenshot[y1:y2, x1:x2]
+
+        # Validate crop is not empty
+        if deck_crop.size == 0:
+            logger.log("Failed to crop deck region: resulting crop is empty")
+            return False
+
+        # Generate filename with timestamp
+        timestamp = time.strftime("%Y-%m-%d_%H-%M-%S", time.localtime())
+        filename = f"deck_{timestamp}.png"
+        filepath = join(DECK_SCREENSHOT_DIR, filename)
+
+        # Save the cropped deck image (screenshot is already in BGR format)
+        success = cv2.imwrite(filepath, deck_crop)
+        if not success:
+            logger.log(f"Failed to save deck screenshot to {filepath}")
+            return False
+
+        # Verify file was actually created
+        if not os.path.exists(filepath):
+            logger.log(f"File was not created at {filepath}")
+            return False
+
+        # Optionally send to webhook if configured
+        if DECK_SCREENSHOT_WEBHOOK_URL:
+            try:
+                # Read image bytes for webhook
+                with open(filepath, "rb") as f:
+                    image_bytes = f.read()
+                send_deck_screenshot_webhook(image_bytes, DECK_SCREENSHOT_WEBHOOK_URL, timestamp=timestamp)
+            except Exception as e:
+                # Silently fail - don't interrupt screenshot saving
+                pass
+
+        logger.log(f"Captured deck screenshot during battle: {filename}")
+        return True
+
+    except Exception as e:
+        logger.log(f"Error capturing deck screenshot: {e}")
+        import traceback
+        logger.log(f"Traceback: {traceback.format_exc()}")
+        return False

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -565,7 +565,7 @@ def play_a_card(emulator, logger, recording_flag: bool, battle_strategy: "Battle
     emulator.click(play_coord[0], play_coord[1])
     click_and_play_card_time_taken = str(time.time() - click_and_play_card_start_time)[:3]
     if recording_flag:
-        save_play(play_coord, card_index)
+        save_play(play_coord, card_index, emulator)
 
     logger.change_status(f"Made the play {click_and_play_card_time_taken}s")
     logger.add_card_played()

--- a/pyclashbot/interface/enums.py
+++ b/pyclashbot/interface/enums.py
@@ -41,6 +41,7 @@ class UIField(StrEnum):
     RANDOM_PLAYS_USER_TOGGLE = "random_plays_user_toggle"
     DISABLE_WIN_TRACK_TOGGLE = "disable_win_track_toggle"
     RECORD_FIGHTS_TOGGLE = "record_fights_toggle"
+    CAPTURE_DECK_SCREENSHOTS_TOGGLE = "capture_deck_screenshots_toggle"
     OPENGL_TOGGLE = "opengl_toggle"
     DIRECTX_TOGGLE = "directx_toggle"
     BS_RENDERER_GL = "bs_renderer_gl"

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -55,6 +55,7 @@ class PyClashBotUI(ttk.Window):
         self._config_callback: Callable[[dict[str, object]], None] | None = None
         self._open_recordings_callback: Callable[[], None] | None = None
         self._open_logs_callback: Callable[[], None] | None = None
+        self._open_deck_screenshots_callback: Callable[[], None] | None = None
         self._config_widgets: dict[str, tk.Widget] = {}
         self._theme_labels: list[tk.Widget] = []
         self._traces: list[tuple[tk.Variable, str]] = []
@@ -76,6 +77,13 @@ class PyClashBotUI(ttk.Window):
     def register_open_logs_callback(self, callback: Callable[[], None]) -> None:
         self._open_logs_callback = callback
 
+    def register_open_deck_screenshots_callback(self, callback: Callable[[], None]) -> None:
+        self._open_deck_screenshots_callback = callback
+
+    def _on_open_deck_screenshots_clicked(self) -> None:
+        if self._open_deck_screenshots_callback:
+            self._open_deck_screenshots_callback()
+
     def get_all_values(self) -> dict[str, object]:
         values: dict[str, object] = {}
         for field, var in self.jobs_vars.items():
@@ -85,6 +93,7 @@ class PyClashBotUI(ttk.Window):
         values[UIField.CYCLE_DECKS_USER_TOGGLE.value] = bool(self.jobs_vars[UIField.CYCLE_DECKS_USER_TOGGLE].get())
         values[UIField.MAX_DECK_SELECTION.value] = self._safe_int(self.max_deck_var.get(), fallback=2)
         values[UIField.RECORD_FIGHTS_TOGGLE.value] = bool(self.record_var.get())
+        values[UIField.CAPTURE_DECK_SCREENSHOTS_TOGGLE.value] = bool(self.capture_deck_var.get())
 
         emulator_choice = self.emulator_var.get()
         values[UIField.MEMU_EMULATOR_TOGGLE.value] = emulator_choice == "MEmu"
@@ -123,6 +132,8 @@ class PyClashBotUI(ttk.Window):
                 self.max_deck_var.set(str(values[UIField.MAX_DECK_SELECTION.value]))
             if UIField.RECORD_FIGHTS_TOGGLE.value in values:
                 self.record_var.set(bool(values[UIField.RECORD_FIGHTS_TOGGLE.value]))
+            if UIField.CAPTURE_DECK_SCREENSHOTS_TOGGLE.value in values:
+                self.capture_deck_var.set(bool(values[UIField.CAPTURE_DECK_SCREENSHOTS_TOGGLE.value]))
 
             if UIField.THEME_NAME.value in values:
                 theme_value = str(values[UIField.THEME_NAME.value])
@@ -711,6 +722,18 @@ class PyClashBotUI(ttk.Window):
         self._trace_variable(self.record_var)
         self._register_config_widget(UIField.RECORD_FIGHTS_TOGGLE.value, record_checkbox)
 
+        self.capture_deck_var = ttk.BooleanVar()
+        capture_deck_checkbox = ttk.Checkbutton(
+            data_frame,
+            text="Capture deck screenshots during battle (every 5s)",
+            variable=self.capture_deck_var,
+            bootstyle="round-toggle",
+            command=self._notify_config_change,
+        )
+        capture_deck_checkbox.pack(anchor="w", pady=(6, 0))
+        self._trace_variable(self.capture_deck_var)
+        self._register_config_widget(UIField.CAPTURE_DECK_SCREENSHOTS_TOGGLE.value, capture_deck_checkbox)
+
         self.open_recordings_btn = ttk.Button(
             data_frame,
             text="Open Recordings Folder",
@@ -724,6 +747,13 @@ class PyClashBotUI(ttk.Window):
             command=self._on_open_logs_clicked,
         )
         self.open_logs_btn.pack(fill="x", pady=(6, 0))
+
+        self.open_deck_screenshots_btn = ttk.Button(
+            data_frame,
+            text="Open Deck Screenshots Folder",
+            command=self._on_open_deck_screenshots_clicked,
+        )
+        self.open_deck_screenshots_btn.pack(fill="x", pady=(6, 0))
 
         ttk.Separator(self.misc_tab, orient="horizontal").pack(fill="x", padx=10, pady=(6, 0))
         display_frame = ttk.Labelframe(self.misc_tab, text="Display Settings", padding=10)

--- a/pyclashbot/utils/webhook.py
+++ b/pyclashbot/utils/webhook.py
@@ -1,0 +1,166 @@
+"""Webhook utility for sending deck screenshots and data to external endpoints."""
+
+import io
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
+
+# Webhook URL configuration
+# Set this to your webhook URL to automatically send deck screenshots when captured
+# Leave empty or None to disable webhook functionality
+DECK_SCREENSHOT_WEBHOOK_URL: str | None = None
+
+# Example:
+# DECK_SCREENSHOT_WEBHOOK_URL = "https://your-webhook-url.com/api/deck-screenshots"
+
+
+def send_image_to_webhook(
+    image_data: bytes,
+    webhook_url: str,
+    filename: str = "deck_screenshot.png",
+    additional_data: dict[str, Any] | None = None,
+    timeout: int = 10,
+) -> bool:
+    """Send an image to a webhook endpoint using multipart/form-data.
+
+    Args:
+        image_data: Image bytes (PNG format)
+        webhook_url: Webhook endpoint URL
+        filename: Filename for the image
+        additional_data: Optional dictionary of additional fields to send
+        timeout: Request timeout in seconds
+
+    Returns:
+        True if successful, False otherwise
+    """
+    if not webhook_url or not webhook_url.strip():
+        return False
+
+    try:
+        # Parse URL to validate it
+        parsed = urlparse(webhook_url)
+        if not parsed.scheme or not parsed.netloc:
+            return False
+
+        # Create multipart/form-data request
+        boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+        crlf = b"\r\n"
+        
+        # Build multipart body parts
+        body_parts = []
+        
+        # Add image file
+        body_parts.append(f"--{boundary}".encode("utf-8"))
+        body_parts.append(
+            f'Content-Disposition: form-data; name="image"; filename="{filename}"'.encode("utf-8")
+        )
+        body_parts.append(b"Content-Type: image/png")
+        body_parts.append(b"")
+        body_parts.append(image_data)  # Binary image data
+        
+        # Add additional data fields if provided
+        if additional_data:
+            for key, value in additional_data.items():
+                body_parts.append(f"--{boundary}".encode("utf-8"))
+                body_parts.append(f'Content-Disposition: form-data; name="{key}"'.encode("utf-8"))
+                body_parts.append(b"")
+                body_parts.append(str(value).encode("utf-8"))
+        
+        body_parts.append(f"--{boundary}--".encode("utf-8"))
+        
+        # Join all parts with CRLF
+        final_body = crlf.join(body_parts)
+
+        # Create request
+        request = Request(webhook_url, data=final_body)
+        request.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+        request.add_header("Content-Length", str(len(final_body)))
+
+        # Send request
+        with urlopen(request, timeout=timeout) as response:
+            # Check if status code indicates success (200-299)
+            if 200 <= response.getcode() < 300:
+                return True
+            return False
+
+    except (HTTPError, URLError, ValueError, Exception) as e:
+        # Silently fail - don't interrupt bot operation
+        return False
+
+
+def send_json_to_webhook(
+    data: dict[str, Any],
+    webhook_url: str,
+    timeout: int = 10,
+) -> bool:
+    """Send JSON data to a webhook endpoint.
+
+    Args:
+        data: Dictionary of data to send as JSON
+        webhook_url: Webhook endpoint URL
+        timeout: Request timeout in seconds
+
+    Returns:
+        True if successful, False otherwise
+    """
+    if not webhook_url or not webhook_url.strip():
+        return False
+
+    try:
+        # Parse URL to validate it
+        parsed = urlparse(webhook_url)
+        if not parsed.scheme or not parsed.netloc:
+            return False
+
+        # Create JSON request
+        json_data = json.dumps(data).encode("utf-8")
+
+        request = Request(webhook_url, data=json_data)
+        request.add_header("Content-Type", "application/json")
+        request.add_header("Content-Length", str(len(json_data)))
+
+        # Send request
+        with urlopen(request, timeout=timeout) as response:
+            # Check if status code indicates success (200-299)
+            if 200 <= response.getcode() < 300:
+                return True
+            return False
+
+    except (HTTPError, URLError, ValueError, Exception) as e:
+        # Silently fail - don't interrupt bot operation
+        return False
+
+
+def send_deck_screenshot_webhook(
+    image_data: bytes,
+    webhook_url: str,
+    timestamp: str | None = None,
+    play_coord: tuple[int, int] | None = None,
+    card_index: int | None = None,
+) -> bool:
+    """Send deck screenshot to webhook with optional metadata.
+
+    Args:
+        image_data: Image bytes (PNG format)
+        webhook_url: Webhook endpoint URL
+        timestamp: Optional timestamp string
+        play_coord: Optional play coordinates tuple (x, y)
+        card_index: Optional card index
+
+    Returns:
+        True if successful, False otherwise
+    """
+    additional_data = {}
+    if timestamp:
+        additional_data["timestamp"] = timestamp
+    if play_coord:
+        additional_data["play_coord_x"] = play_coord[0]
+        additional_data["play_coord_y"] = play_coord[1]
+    if card_index is not None:
+        additional_data["card_index"] = card_index
+
+    filename = f"deck_{timestamp or 'screenshot'}.png"
+    return send_image_to_webhook(image_data, webhook_url, filename, additional_data)
+


### PR DESCRIPTION
# Deck screenshot capture

Adds deck screenshot capture during battles. Takes a screenshot of the deck area every 5 seconds when in battle, and also captures one automatically whenever a play recording is saved.

Screenshots go to `%localappdata%\programs\py-clash-bot\deck_screenshots\`. There's a toggle in the Misc tab to enable it.

Also added webhook support - if you set `DECK_SCREENSHOT_WEBHOOK_URL` in `webhook.py` it'll send screenshots to your endpoint. Uses multipart/form-data and includes metadata like timestamp and play coords if available.

New files: `deck_screenshot.py`, `webhook.py`
Modified: `recorder.py`, `fight.py`, `worker.py`, `ui.py`, `enums.py`, `__main__.py`

Disabled by default, no breaking changes.

