### PR TITLE
Fix deadspace click coordinates for "New Year, New Fire" event

### DIFF
--- a/pyclashbot/emulators/adb.py
+++ b/pyclashbot/emulators/adb.py
@@ -381,7 +381,7 @@ class AdbController(AdbBasedController):
                 return True
 
             # Click in a safe area to dismiss potential pop-ups
-            self.click(5, 350)
+            self.click(35, 405)
             interruptible_sleep(2)
 
         self.logger.change_status("Timeout waiting for Clash Royale main menu. Please check the device.")

--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -694,7 +694,7 @@ class BlueStacksEmulatorController(AdbBasedController):
                 dur = f"{time.time() - start_ts:.1f}s"
                 self.logger.log(f"BlueStacks 5 restart completed in {dur}")
                 return True
-            self.click(5, 350)  # Use inherited click
+            self.click(35, 405)  # Use inherited click
 
         self.logger.change_status("Timeout waiting for Clash main menu - retrying...")
         return False

--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -434,7 +434,7 @@ class GooglePlayEmulatorController(AdbBasedController):
                 break
 
             # click deadspace
-            self.click(5, 350)
+            self.click(35, 405)
 
         restart_duration = str(time.time() - restart_start_time)[:5]
         self.logger.change_status(f"Google Play emulator restart completed successfully in {restart_duration}s")

--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -1354,7 +1354,7 @@ class MemuEmulatorController(BaseEmulatorController):
 
                 # Click deadspace to handle any popups
                 click_start = time.time()
-                self.click(5, 350)
+                self.click(35, 405)
                 click_end = time.time()
 
                 if debug_clash:


### PR DESCRIPTION
## Summary
Updates the "deadspace" click coordinates used to dismiss popups on the main menu.

## The Issue
The previous safe click coordinates `(5, 350)` now land on the newly added "cart with gems" icon for the "NEW YEAR NEW FIRE" event. This causes the bot to open the event page instead of dismissing popups, trapping it in a loop since it cannot exit this screen.

## The Fix
Updated the coordinates to `(35, 405)` across all emulators (`adb`, `bluestacks`, `google_play`, `memu`). This shifts the click slightly to the right and down, effectively avoiding the new event icon.

## Notes
I am not entirely sure if these new coordinates will handle *all* other popups as safely as the previous ones, as I don't know the full extent of popups the original coordinates were intended to catch. However, this change definitively resolves the critical issue with the new event icon.