### PR TITLE
fix: clicks standard popup close button location when main menu check fails on menu states

### DIFF
--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -19,20 +19,12 @@ OK_BUTTON_COORDS_IN_TROPHY_REWARD_PAGE = (209, 599)
 CLASH_MAIN_WAIT_TIMEOUT = 240  # s
 
 
-def try_close_bottom_center_popup(
-    emulator,
-    logger: Logger | None = None,
-    printmode: bool = False,
-) -> bool:
+def try_close_bottom_center_popup(emulator, logger: Logger) -> bool:
     """Pressing close button for generic rewards/promo windows.
 
     Uses the same coordinate as trophy-road OK button.
     """
-    if logger is not None:
-        if printmode:
-            logger.change_status("Trying bottom-center popup close")
-        else:
-            logger.log("Trying bottom-center popup close")
+    logger.log("Trying bottom-center popup close")
 
     emulator.click(
         OK_BUTTON_COORDS_IN_TROPHY_REWARD_PAGE[0],
@@ -684,7 +676,7 @@ def select_mode(emulator, mode: str):
         print(f'[!] Warning: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.')
         return False
 
-    # Must be on clash main. Popup recovery is handled in state_tree preflight
+    # must be on clash main
     if not check_if_on_clash_main_menu(emulator):
         print("[!] Not on clash main menu, cannot select a fight mode")
         return False

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -19,6 +19,30 @@ OK_BUTTON_COORDS_IN_TROPHY_REWARD_PAGE = (209, 599)
 CLASH_MAIN_WAIT_TIMEOUT = 240  # s
 
 
+def try_close_bottom_center_popup(
+    emulator,
+    logger: Logger | None = None,
+    printmode: bool = False,
+) -> bool:
+    """Pressing close button for generic rewards/promo windows.
+
+    Uses the same coordinate as trophy-road OK button.
+    """
+    if logger is not None:
+        if printmode:
+            logger.change_status("Trying bottom-center popup close")
+        else:
+            logger.log("Trying bottom-center popup close")
+
+    emulator.click(
+        OK_BUTTON_COORDS_IN_TROPHY_REWARD_PAGE[0],
+        OK_BUTTON_COORDS_IN_TROPHY_REWARD_PAGE[1],
+    )
+    interruptible_sleep(1)
+
+    return check_if_on_clash_main_menu(emulator)
+
+
 def wait_for_battle_start(emulator, logger, timeout: int = 120) -> bool:
     """Waits for any battle to start (1v1 or 2v2).
 
@@ -660,7 +684,7 @@ def select_mode(emulator, mode: str):
         print(f'[!] Warning: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.')
         return False
 
-    # must be on clash main
+    # Must be on clash main. Popup recovery is handled in state_tree preflight
     if not check_if_on_clash_main_menu(emulator):
         print("[!] Not on clash main menu, cannot select a fight mode")
         return False

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -12,7 +12,12 @@ from pyclashbot.bot.fight import (
     end_fight_state,
     start_fight,
 )
-from pyclashbot.bot.nav import check_if_battle_mode_is_selected, select_mode
+from pyclashbot.bot.nav import (
+    check_if_battle_mode_is_selected,
+    check_if_on_clash_main_menu,
+    select_mode,
+    try_close_bottom_center_popup,
+)
 from pyclashbot.bot.upgrade_state import upgrade_cards_state
 from pyclashbot.interface.enums import UIField
 from pyclashbot.utils.caching import (
@@ -48,6 +53,14 @@ def handle_state_failure(logger: Logger, state_name: str, function_name: str, er
 
 mode_used_in_1v1 = None
 fight_mode_cycle_index = 0
+MENU_RECOVERY_STATES = {
+    "upgrade",
+    "card_mastery",
+    "select_battle_mode",
+    "randomize_deck",
+    "cycle_deck",
+    "start_fight",
+}
 
 
 def get_next_fight_mode(job_list):
@@ -249,6 +262,13 @@ def state_tree(
         logger.error("State machine entered 'fail' state - stopping execution")
         logger.add_restart_after_failure()
         raise RuntimeError("State machine entered fail state - unrecoverable error")
+
+    # preflight recovery for menu-driven states:
+    # if an unexpected popup blocks main-menu recognition, close it before running state-specific logic.
+    if state in MENU_RECOVERY_STATES and not check_if_on_clash_main_menu(emulator):
+        logger.log(f"Preflight popup recovery before '{state}' state")
+        try_close_bottom_center_popup(emulator, logger)
+        interruptible_sleep(0.5)
 
     if state == "start":
         return state_order.next_state(state)

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -53,14 +53,6 @@ def handle_state_failure(logger: Logger, state_name: str, function_name: str, er
 
 mode_used_in_1v1 = None
 fight_mode_cycle_index = 0
-MENU_RECOVERY_STATES = {
-    "upgrade",
-    "card_mastery",
-    "select_battle_mode",
-    "randomize_deck",
-    "cycle_deck",
-    "start_fight",
-}
 
 
 def get_next_fight_mode(job_list):
@@ -263,18 +255,24 @@ def state_tree(
         logger.add_restart_after_failure()
         raise RuntimeError("State machine entered fail state - unrecoverable error")
 
-    # preflight recovery for menu-driven states:
-    # if an unexpected popup blocks main-menu recognition, close it before running state-specific logic.
-    if state in MENU_RECOVERY_STATES and not check_if_on_clash_main_menu(emulator):
-        logger.log(f"Preflight popup recovery before '{state}' state")
-        try_close_bottom_center_popup(emulator, logger)
-        interruptible_sleep(0.5)
-
     if state == "start":
+        # if not on clash main, try to recover
+        if not check_if_on_clash_main_menu(emulator):
+            logger.log("Not on clash main, trying to recover")
+            try_close_bottom_center_popup(emulator, logger)
+            interruptible_sleep(0.5)
+
         return state_order.next_state(state)
 
     if state == "restart":
         emulator.restart()
+
+        # if not on clash main, try to recover
+        if not check_if_on_clash_main_menu(emulator):
+            logger.log("Not on clash main, trying to recover")
+            try_close_bottom_center_popup(emulator, logger)
+            interruptible_sleep(0.5)
+
         return state_order.next_state(state)
 
     if state == "randomize_deck":


### PR DESCRIPTION
Added global var in states.py that contains the names of all menu related states:
upgrade, card_mastery, select_battle_mode, randomize_deck, cycle_deck, start_fight

Before any state-specific logic is executed in the state_tree() it checks if the current state is one of these AND if check_if_on_clash_main_menu() fails. If so, something unexpected is causing menu recognition to fail. It then calls the function try_close_bottom_center_popup() in nav.py which clicks the standard close button location in the bottom middle (same coordinates as OK in trophy reward page).

Some users have unexpected popups on startup that make it restart indefinitely which this handles:
https://github.com/user-attachments/assets/d1f0f744-9fd1-4d84-aba7-90c59cc8a1ad
