### PR TITLE
Fix main menu detection for Google Play with alternate render settings

### DIFF
--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -282,6 +282,17 @@ def check_if_on_clash_main_menu(emulator) -> bool:
         [155, 120, 81],
     ]
 
+    # Google Play with different rendering settings colors
+    colors_3 = [
+        [57, 151, 206],
+        [21, 148, 42],
+        [36, 17, 1],
+        [231, 190, 123],
+        [140, 105, 74],
+        [140, 105, 74],
+        [156, 121, 82],
+    ]
+
     # print("{:^15} | {:^15} | {:^15}".format("Seen", "Google", "Memu"))
     # for seen_pixel, google_play_color, memu_color in zip(pixels, colors_1, colors_2):
     #     seen_pixel =str(seen_pixel[0])+ ' '+ str(seen_pixel[1])+ ' '+ str(seen_pixel[2])
@@ -295,7 +306,7 @@ def check_if_on_clash_main_menu(emulator) -> bool:
     #         "{:^15} | {:^15} | {:^15}".format(seen_pixel, google_play_color, memu_color)
     #     )
 
-    for colors in [colors_1, colors_2]:
+    for colors in [colors_1, colors_2, colors_3]:
         if all_pixels_are_equal(
             pixels,
             colors,


### PR DESCRIPTION
## Summary
- Adds a third color signature variant in `check_if_on_clash_main_menu` to detect the Clash main menu when the Google Play emulator is configured with non-default rendering settings (which shifts the sampled pixel colors).
- Fix sourced from a community report; follows the existing pattern of listing per-emulator color signatures and iterating through them.

## Test plan
- [ ] Launch bot against a Google Play emulator with default render settings — main menu still detected (colors_1).
- [ ] Launch bot against MEmu — main menu still detected (colors_2).
- [ ] Launch bot against Google Play with alternate render settings that previously broke detection — main menu now detected (colors_3).