### PR TITLE
Update main menu color signature after Clash Royale app update

### DIFF
--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -282,6 +282,17 @@ def check_if_on_clash_main_menu(emulator) -> bool:
         [155, 120, 81],
     ]
 
+    # post Clash Royale app update colors
+    colors_3 = [
+        [57, 151, 206],
+        [21, 148, 42],
+        [36, 17, 1],
+        [231, 190, 123],
+        [140, 105, 74],
+        [140, 105, 74],
+        [156, 121, 82],
+    ]
+
     # print("{:^15} | {:^15} | {:^15}".format("Seen", "Google", "Memu"))
     # for seen_pixel, google_play_color, memu_color in zip(pixels, colors_1, colors_2):
     #     seen_pixel =str(seen_pixel[0])+ ' '+ str(seen_pixel[1])+ ' '+ str(seen_pixel[2])
@@ -295,7 +306,7 @@ def check_if_on_clash_main_menu(emulator) -> bool:
     #         "{:^15} | {:^15} | {:^15}".format(seen_pixel, google_play_color, memu_color)
     #     )
 
-    for colors in [colors_1, colors_2]:
+    for colors in [colors_1, colors_2, colors_3]:
         if all_pixels_are_equal(
             pixels,
             colors,


### PR DESCRIPTION
## Summary
- The latest Clash Royale app update changed how the main menu renders, shifting the sampled pixel colors and breaking `check_if_on_clash_main_menu`.
- Add a new color variant alongside the existing emulator-specific signatures so detection works against the updated app.

## Test plan
- [x] Confirm bot detects the Clash main menu on the current (post-update) Clash Royale build.
- [x] Confirm existing detection paths (`colors_1`, `colors_2`) still work on emulators that haven't pulled the update yet.