### PR TITLE
fix(build): make Windows MSI build compatible with cx-freeze 8.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ homepage = "https://pyclashbot.app"
 
 [dependency-groups]
 build = [
-    "cx-freeze>=8.3.0,<9; sys_platform == 'win32'",
+    "cx-freeze>=8.6.4,<9; sys_platform == 'win32'",
     "pyinstaller>=6.0.0,<7; sys_platform == 'darwin'",
     "packaging>=24.2",
     "requests>=2.32.4",

--- a/scripts/setup_msi.py
+++ b/scripts/setup_msi.py
@@ -17,8 +17,14 @@ GUI = True
 UPGRADE_CODE = "{494bebef-6fc5-42e5-98c8-d0b2e339750e}"
 
 
+# Parse the home-made --target-version flag used to stamp the __version__ file,
+# then strip it (and its value) from sys.argv so cx_Freeze's bdist_msi command
+# parser never sees it. cx_Freeze 8.4+ removed the bdist_msi `target_version`
+# option, so leaving it on the command line raises a hard error.
 try:
-    VERSION = sys.argv[sys.argv.index("--target-version") + 1]
+    _version_idx = sys.argv.index("--target-version")
+    VERSION = sys.argv[_version_idx + 1]
+    del sys.argv[_version_idx : _version_idx + 2]
 except (ValueError, IndexError):
     VERSION = "v0.0.0"
 

--- a/scripts/setup_msi.py
+++ b/scripts/setup_msi.py
@@ -17,10 +17,7 @@ GUI = True
 UPGRADE_CODE = "{494bebef-6fc5-42e5-98c8-d0b2e339750e}"
 
 
-# Parse the home-made --target-version flag used to stamp the __version__ file,
-# then strip it (and its value) from sys.argv so cx_Freeze's bdist_msi command
-# parser never sees it. cx_Freeze 8.4+ removed the bdist_msi `target_version`
-# option, so leaving it on the command line raises a hard error.
+# Read --target-version and drop it from argv; cx_Freeze 8.4+ errors if bdist_msi sees it.
 try:
     _version_idx = sys.argv.index("--target-version")
     VERSION = sys.argv[_version_idx + 1]

--- a/scripts/setup_msi.py
+++ b/scripts/setup_msi.py
@@ -17,7 +17,6 @@ GUI = True
 UPGRADE_CODE = "{494bebef-6fc5-42e5-98c8-d0b2e339750e}"
 
 
-# Read --target-version and drop it from argv; cx_Freeze 8.4+ errors if bdist_msi sees it.
 try:
     _version_idx = sys.argv.index("--target-version")
     VERSION = sys.argv[_version_idx + 1]

--- a/uv.lock
+++ b/uv.lock
@@ -75,32 +75,18 @@ wheels = [
 
 [[package]]
 name = "cx-freeze"
-version = "8.3.0"
+version = "8.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cabarchive", marker = "sys_platform == 'win32'" },
-    { name = "cx-logging", marker = "platform_machine != 'ARM64' and sys_platform == 'win32'" },
-    { name = "filelock", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "lief", marker = "platform_machine != 'ARM64' and sys_platform == 'win32'" },
+    { name = "filelock", marker = "platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
+    { name = "freeze-core", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "lief", marker = "sys_platform == 'win32'" },
     { name = "packaging", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "setuptools", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "striprtf", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fa/835edcb0bbfffc09bea4a723c26779e3691513c6bfd41dc92498289218be/cx_freeze-8.3.0.tar.gz", hash = "sha256:491998d513f04841ec7967e2a3792db198597bde8a0c9333706b1f96060bdb35", size = 3180070, upload-time = "2025-05-12T00:18:41.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/9c/11c9386d4de038da0052910bce2a9aa2313b25cde2c2666069a5b333332c/cx_freeze-8.6.4.tar.gz", hash = "sha256:16227706ad06b4b96f77c48980e2b363f0302c971f66c6b05567fd63a27596a4", size = 1377425, upload-time = "2026-04-13T06:00:31.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/1a/64c825770df0b9cb69e5f15c2647e708bf8e13f55da1011749658bc83c37/cx_freeze-8.3.0-cp312-cp312-win32.whl", hash = "sha256:3bad93b5e44c9faee254b0b27a1698c053b569122e73a32858b8e80e340aa8f2", size = 2336981, upload-time = "2025-05-12T00:17:57.116Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/68/09458532149bcb26bbc078ed232c2f970476d6381045ce76de32ef6014c2/cx_freeze-8.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:82887045c831e5c03f4a33f8baab826b785c6400493a077c482cc45c15fd531c", size = 2341781, upload-time = "2025-05-12T00:17:59.198Z" },
-    { url = "https://files.pythonhosted.org/packages/82/fe/ebe723ade801df8f1030d90b9b676efd43bbf12ca833bb4b82108101ed8e/cx_freeze-8.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:72b9d7e3e98bbc175096b66e67208aea5b2e283f07e3d826c40f89f60a821ae1", size = 2329301, upload-time = "2025-05-12T00:18:00.734Z" },
-]
-
-[[package]]
-name = "cx-logging"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/15/7a2e83df1dbe7f8d7aee95eff2b9a9f90ab3dd048cce71e82be43e205050/cx_Logging-3.2.0.tar.gz", hash = "sha256:bdbad6d2e6a0cc5bef962a34d7aa1232e88ea9f3541d6e2881675b5e7eab5502", size = 26933, upload-time = "2024-03-23T03:18:03.484Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/f6/3fcdd2370018953cf49955e0a159218585c4e8088632eb7f7587a4d7850b/cx_Logging-3.2.0-cp312-cp312-win32.whl", hash = "sha256:4328097f6034be241e02146af8e199382e7f30019272c26768e4cd3e5122d3f9", size = 22591, upload-time = "2024-03-23T03:18:25.483Z" },
-    { url = "https://files.pythonhosted.org/packages/72/90/14eebfbd0256f391ccac1434a7771a30eb973776b3726e9da8eb8bb89f02/cx_Logging-3.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:2496386a36f63233fe77e7e68539910b9429df2f922be1af71309be59dca11f3", size = 26726, upload-time = "2024-03-23T03:18:26.506Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b2/22eacec14d521da35211b5fc368da9ee68c2dc91b9fcf0c90bdbfe9b2306/cx_freeze-8.6.4-py3-none-any.whl", hash = "sha256:37f1ac07d1c2f5e6e28eaf71bc24cb8300045d5e9998447fdc9662471ce6df88", size = 251189, upload-time = "2026-04-13T06:00:29.421Z" },
 ]
 
 [[package]]
@@ -119,6 +105,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "freeze-core"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cabarchive", marker = "sys_platform == 'win32'" },
+    { name = "filelock", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "striprtf", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/0d/1415721fce1b24d88c1460f67059678d7e5a5975baccf5dde790f2158bf7/freeze_core-0.6.1.tar.gz", hash = "sha256:819642aa58b4e2c19e1ade025d9563e437c07c90fe6ac5c891e8ecee2044a2ef", size = 1636378, upload-time = "2026-03-10T13:24:03.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/39/a370542fe43cee7628a9fa20a37ec3c5087caba0a8c70efea2aa33767470/freeze_core-0.6.1-cp312-cp312-win32.whl", hash = "sha256:58b237d75fc88051c99e7a6201068a118b20df4f72a1375cdb7aa3ca728c2d00", size = 1727664, upload-time = "2026-03-10T13:22:28.416Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ed/d40cfb105d0fb8d550be9bcecf6c322d1bd1bc90f8e1925d25b8d7f7b718/freeze_core-0.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:1c95b6d5e7b490582d81fad84bc54e6144dc581ff9f36e10f2c221373ac9e1ca", size = 1732937, upload-time = "2026-03-10T13:22:29.837Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/38/eae012527a2483c82cb534208747ae757a9bee681c1b38581c1b32188e0b/freeze_core-0.6.1-cp312-cp312-win_arm64.whl", hash = "sha256:4379f1145d329a2232435cef7f8ea3342aa5e24dfe2db003a3df18751ab02627", size = 1720985, upload-time = "2026-03-10T13:22:31.442Z" },
 ]
 
 [[package]]
@@ -312,7 +314,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 build = [
-    { name = "cx-freeze", marker = "sys_platform == 'win32'", specifier = ">=8.3.0,<9" },
+    { name = "cx-freeze", marker = "sys_platform == 'win32'", specifier = ">=8.6.4,<9" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pyinstaller", marker = "sys_platform == 'darwin'", specifier = ">=6.0.0,<7" },
     { name = "requests", specifier = ">=2.32.4" },


### PR DESCRIPTION
## Problem

The **Build Windows MSI** check started failing on PRs (e.g. #646) with:

```
error: target_version option was removed, use project.version or product_version instead
```

This is **not** caused by any dependency the failing PRs changed — it's a fresh upstream cx-freeze release. cx-freeze **8.4+** removed the `target_version` option from the `bdist_msi` command. The build runs:

```
uv run --group build scripts/setup_msi.py bdist_msi --target-version v0.0.0
```

`--target-version` is a *home-made* flag the script reads from `sys.argv` to stamp the `pyclashbot/__version__` file. Because it sits after `bdist_msi` on the command line, cx-freeze's command parser also consumed it. Older cx-freeze tolerated the unknown option; 8.6 raises a hard error.

Master's lockfile still pins cx-freeze 8.3.0 (so master builds pass for now), but any PR whose lockfile re-resolves cx-freeze within the `<9` range (e.g. a Dependabot run) pulls 8.6.x and breaks. This will hit master too once 8.3.0 ages out.

## Fix

- **`scripts/setup_msi.py`** — after reading `--target-version`, strip the flag *and its value* from `sys.argv` so it never reaches the `bdist_msi` command parser.
- **`pyproject.toml` / `uv.lock`** — bump cx-freeze to **8.6.4** (latest).

The MSI's product version is derived from `project.version` (`v0.0.0` → `0.0.0`), not from this flag, so behavior is unchanged. macOS (PyInstaller) was never affected — it doesn't strict-parse argv.

## Verification

- `pre-commit run` (ruff, ruff-format, validate-pyproject) passes on the changed files.
- argv-stripping logic unit-checked for both the `--target-version <v>` and default paths.
- The Windows `bdist_msi` step itself is Windows-only, so final validation is this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)