### PR TITLE
docs: add CLAUDE.md / AGENTS.md agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# py-clash-bot
+
+A Clash Royale automation bot: drives an Android emulator via ADB and acts on the screen using OpenCV image recognition and hardcoded pixel checks. Treat it as a screen-scraping state machine — there is no game API.
+
+## Commands
+
+Targets live in the `Makefile` (`make setup`/`dev`/`lint`/`test`, `build-msi`/`build-dmg`, all via `uv`); `CONTRIBUTING.md` has dev setup. Non-obvious bits those don't tell you:
+- Tests are **not** pytest — each `tests/**/test_*.py` runs as a standalone script (exit 0 = pass); `EMULATOR=memu make test` filters to `tests/<name>/`.
+- `tests/clash-royale/` are integration tests needing a live MEmu VM and **do not run in CI**. CI only builds artifacts + runs pre-commit.
+- MSI build = cx-freeze, DMG = pyinstaller; both inject the real version (see Cross-cutting rules).
+
+## Architecture
+
+`pyclashbot/__main__.py` wires the `interface/` GUI to a `bot/worker.py` `WorkerProcess` running in a separate process; they communicate over `multiprocessing` `Queue` (stats) + `Event` (shutdown). The worker runs a state-machine loop (`bot/states.py`) that calls `emulators/` for screen I/O and `detection/` for image recognition. Subdirectories under `pyclashbot/` have their own `AGENTS.md` — read it before editing that layer.
+
+## Cross-cutting rules
+
+- **Never call `time.sleep()`** — it is lint-banned. Use `interruptible_sleep()` from `pyclashbot.utils.cancellation` so shutdown is responsive. The active `CancellationToken` is thread-local; worker threads must `CancellationToken.set_current(token)`.
+- **All screen coordinates are absolute to a fixed emulator resolution (~419×633).** There is no scaling — every click/pixel-check constant breaks if the resolution changes.
+- Detection keeps multiple color palettes (with tolerance) to absorb emulator/app-version drift; add fallbacks, don't tighten thresholds.
+- Always verify screen state (a `check_if_on_*` / detection call) **before** clicking. Never hardcode a raw click — use named coordinate constants or nav helpers.
+- Persistent user settings go through `USER_SETTINGS_CACHE` (`pyclashbot.utils.caching`), keyed by `UIField.value` strings. Logging/stats go through `pyclashbot.utils.logger`; OS checks through `pyclashbot.utils.platform` (`is_windows()`/`is_macos()`).
+- Version is a `v0.0.0` placeholder in `pyproject.toml`; the real version is injected from the git tag at build time and read at runtime from `pyclashbot/__version__` via `utils/versioning.py`.
+- Python 3.12 only. Conventional-commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/pyclashbot/bot/AGENTS.md
+++ b/pyclashbot/bot/AGENTS.md
@@ -1,0 +1,15 @@
+# bot/ — automation state machine
+
+`worker.py` runs the process lifecycle and an infinite loop calling `state_tree()` in `states.py`, which sequences jobs (upgrade → card_mastery → select_battle_mode → randomize/cycle deck → fight → end). Each state returns the next state name; a failed state returns `"restart"`, which restarts the emulator. The worker aborts after **5 consecutive restarts**.
+
+## Adding or editing a state / navigation step
+
+- Call a `check_if_on_*` detection before acting; loop on `interruptible_sleep()` with an explicit timeout (e.g. `wait_for_clash_main_menu()` waits up to 240s and clears reward popups mid-wait). Handle async popups before proceeding.
+- Navigation is consolidated in `nav.py` (post nav-refactor): use `navigate_main_page(emulator, logger, start, end)` and the `NAV_CLICKS` table rather than ad-hoc click sequences. Deck pages use image matching on `DECK_TABS_REGION`.
+- New coordinates go in `constants.py` as named constants — see the resolution warning in the root `AGENTS.md`.
+
+## Gotchas
+
+- `states.py` carries **module-level globals** (`mode_used_in_1v1`, `fight_mode_cycle_index`) set in one state and read in later ones; if `mode_used_in_1v1` is `None`, fight/cycle states silently skip.
+- `StateHistory` throttles expensive states (upgrade, card_mastery) by randomized time increments — a manually-triggered state won't re-run until its increment elapses.
+- Card availability and deck tabs use **image recognition** (`card_detection.py`, `find_image`); elixir/battle/upgrade checks use **single-pixel** sampling — an off-by-one Y breaks them.

--- a/pyclashbot/bot/CLAUDE.md
+++ b/pyclashbot/bot/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/pyclashbot/detection/AGENTS.md
+++ b/pyclashbot/detection/AGENTS.md
@@ -1,0 +1,15 @@
+# detection/ — image recognition
+
+`image_rec.py` is the template-matching API over OpenCV (`TM_CCOEFF_NORMED`, grayscale):
+- `find_image(image, folder, tolerance=0.88, subcrop=None)` → `(x, y)` or `None`. `folder` is a subdir of `reference_images/`; **any** template in it matching counts (matched in parallel). `subcrop=(x1,y1,x2,y2)` searches a region and offsets the result back to full-image coords.
+- `compare_images(image, template, threshold=0.8)` → `[y, x]` or `None` — note the **flipped [y, x]** convention vs `find_image`'s `(x, y)`.
+
+## Adding a detectable screen / button
+
+Drop reference PNGs into `reference_images/<descriptive_folder>/` and call `find_image(screenshot, "<folder>")`. Crop a tight region around the element so unrelated screen content can't false-match.
+
+## Gotchas
+
+- Matching is **grayscale** — color-only differences are invisible to it; use the bot layer's pixel/color checks for those.
+- No resolution scaling: templates must be captured at the same ~419×633 emulator resolution (see root `AGENTS.md`).
+- Reference images load via `utils.image_handler` which accepts `.png` only and rejects all-white/all-black images.

--- a/pyclashbot/detection/CLAUDE.md
+++ b/pyclashbot/detection/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/pyclashbot/emulators/AGENTS.md
+++ b/pyclashbot/emulators/AGENTS.md
@@ -1,0 +1,15 @@
+# emulators/ — emulator abstraction
+
+`base.py` defines `BaseEmulatorController` (lifecycle: create → configure → start/restart/stop, plus click/swipe/screenshot/install_apk/start_app). `adb_base.py`'s `AdbBasedController` implements the interaction primitives over ADB shell and is shared by MEmu, BlueStacks, and Google Play; `adb.py` is the plain-device controller. `EmulatorType` in `__init__.py` gates support via each class's `supported_platforms`.
+
+## Adding an emulator
+
+- Subclass `AdbBasedController` if ADB-based — then you only implement `adb(command, binary_output)` and `_check_app_installed(package)`; everything else is inherited (including the install-wait prompt loop). Otherwise subclass `BaseEmulatorController` and implement all abstract methods.
+- Take `logger` as the first `__init__` arg; set `supported_platforms`. `restart()` must leave Clash Royale on a main menu detectable by `check_if_on_clash_main_menu(self)`, else return `False` to trigger the retry loop.
+
+## Gotchas
+
+- Screenshots are `screencap -p` → `cv2.imdecode` → **BGR** numpy, expected ~**419×633**; a size mismatch triggers retry/recovery.
+- Platform-locked: MEmu & Google Play are **Windows-only**; BlueStacks is Win+macOS. Gate paths with `is_windows()`/`is_macos()` from `utils.platform`.
+- Render modes differ per emulator and are written to that emulator's config file then require stop→edit→restart (MEmu int 0/1; BlueStacks `dx`/`gl`/`vlcn`, macOS defaults `vlcn`; Google Play XML).
+- BlueStacks uses a private ADB server (port 5041) and a dynamic per-instance device serial read from `bluestacks.conf`; instance reuse/creation goes through the Multi-Instance Manager — close it after renaming metadata.

--- a/pyclashbot/emulators/CLAUDE.md
+++ b/pyclashbot/emulators/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/pyclashbot/interface/AGENTS.md
+++ b/pyclashbot/interface/AGENTS.md
@@ -1,0 +1,16 @@
+# interface/ — ttkbootstrap GUI
+
+`ui.py` (`PyClashBotUI`) is a tabbed window that never talks to the worker directly: on any change it calls a `config_callback` (registered in `__main__.py`) with `get_all_values()` — a dict keyed by `UIField.value` strings. `__main__.py` persists that to `USER_SETTINGS_CACHE` and maps it to the worker config. `enums.py` names every field (`UIField`, `PRIMARY_JOB_TOGGLES`); `config.py` holds defaults/option lists; `widgets.py` holds custom widgets.
+
+## Adding a setting / toggle / job
+
+Wire the **same key string** across three files or it won't round-trip:
+1. `enums.py` — add a `UIField` member (snake_case value).
+2. `config.py` — add to the right list (`JOBS`, `MEMU_SETTINGS`, etc.) and to the persisted-keys set.
+3. `ui.py` — create the widget in the relevant `_create_*_tab()`, register it, and handle it in `get_all_values()`/`set_all_values()` and `set_button_state()` (the run-time disable list is manual, not auto-discovered).
+
+## Gotchas
+
+- UI keys ≠ worker keys: `__main__.py.make_job_dictionary()` renames some (e.g. `card_upgrade_user_toggle` → `upgrade_user_toggle`) and is where late int-parsing/validation happens.
+- The single emulator combobox expands to **four** boolean `UIField` toggles in get/set — edit all four together.
+- Bulk updates (`set_all_values`) must bump `_suspend_traces` in try/finally to avoid recursive trace callbacks; Google Play comboboxes silently reset invalid persisted values to the first option.

--- a/pyclashbot/interface/CLAUDE.md
+++ b/pyclashbot/interface/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

Adds a hierarchy of agent docs so AI coding agents (and the [agents.md](https://agents.md) standard) have accurate, non-obvious context about this codebase.

- **Root `AGENTS.md`** — ethos, commands, architecture overview, cross-cutting rules.
- **Nested `AGENTS.md`** in `bot/`, `emulators/`, `interface/`, `detection/` — local conventions and contracts only.
- **`CLAUDE.md`** at each level is a one-line `@AGENTS.md` pointer (Claude Code reads `CLAUDE.md` natively; content lives in `AGENTS.md`, shared with the cross-tool standard).

## Principles followed

- **Non-obvious only** — captures what an agent gets wrong without guidance: the `time.sleep` ban (`interruptible_sleep`), the absolute-coordinate / fixed-resolution (~419×633) assumption, the state-machine flow, the emulator subclass contract, the UI three-file wiring, and the image-rec `(x,y)` vs `[y,x]` conventions.
- **Reference, don't repeat** — points to `Makefile`, `CONTRIBUTING.md`, `README.md` instead of restating commands.
- **No repetition across levels** — cross-cutting rules live only in the root; nested files reference them.
- **Tight** — root 24 lines, nested 15–16 each, ~85 total.

Every factual claim was spot-checked against the source (audit verified all symbols, signatures, and the resolution figure). Docs only — no code changes.