### PR TITLE
fix: improve Stats tab layout and standardize UI copy

### DIFF
--- a/pyclashbot/bot/card_mastery_state.py
+++ b/pyclashbot/bot/card_mastery_state.py
@@ -16,7 +16,7 @@ PIXEL_TOLERANCE = 15
 
 
 def card_mastery_state(emulator, logger):
-    logger.change_status("Going to collect card mastery rewards")
+    logger.change_status("Going to collect Card Mastery rewards")
 
     if check_if_on_clash_main_menu(emulator) is not True:
         logger.change_status(
@@ -35,7 +35,7 @@ def card_mastery_state(emulator, logger):
 
 def collect_card_mastery_rewards(emulator, logger: Logger) -> bool:
     # get to card page
-    logger.change_status("Collecting card mastery rewards...")
+    logger.change_status("Collecting Card Mastery rewards...")
     if get_to_card_page_from_clash_main(emulator, logger) == "restart":
         logger.change_status(
             "Failed to get to card page to collect mastery rewards! Returning false",
@@ -44,16 +44,16 @@ def collect_card_mastery_rewards(emulator, logger: Logger) -> bool:
     interruptible_sleep(3)
 
     if not card_mastery_rewards_exist_with_delay(emulator):
-        logger.change_status("No card mastery rewards to collect.")
+        logger.change_status("No Card Mastery rewards to collect.")
         interruptible_sleep(1)
 
     else:
         # while card mastery icon exists:
         while card_mastery_rewards_exist_with_delay(emulator):
-            logger.change_status("Detected card mastery rewards")
+            logger.change_status("Detected Card Mastery rewards")
             #   click card mastery icon
             collect_first_mastery_reward(emulator)
-            logger.change_status("Collected a card mastery reward!")
+            logger.change_status("Collected a Card Mastery reward!")
             logger.add_card_mastery_reward_collection()
             interruptible_sleep(2)
 

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -324,7 +324,7 @@ def state_tree(
     if state == "card_mastery":
         # if job not selected, return next state
         if not job_list[UIField.CARD_MASTERY_USER_TOGGLE]:
-            logger.log("Card mastery job isn't toggled. Skipping this state")
+            logger.log("Card Mastery job isn't toggled. Skipping this state")
             return state_order.next_state(state)
 
         # if job not ready, go next state

--- a/pyclashbot/emulators/__init__.py
+++ b/pyclashbot/emulators/__init__.py
@@ -13,7 +13,7 @@ class EmulatorType(StrEnum):
     """Available emulator types with display names."""
 
     MEMU = "MEmu"
-    GOOGLE_PLAY = "Google Play"
+    GOOGLE_PLAY = "Google Play Games"
     BLUESTACKS = "BlueStacks 5"
     ADB = "ADB Device"
 

--- a/pyclashbot/interface/config.py
+++ b/pyclashbot/interface/config.py
@@ -111,7 +111,7 @@ JOBS = [
     ),
     JobConfig(UIField.RANDOM_PLAYS_USER_TOGGLE, "❔ Random card plays", default=False),
     JobConfig(UIField.DISABLE_WIN_TRACK_TOGGLE, "⏭️ Skip win/loss tracking", default=False),
-    JobConfig(UIField.CARD_MASTERY_USER_TOGGLE, "🎯 Card mastery", default=False),
+    JobConfig(UIField.CARD_MASTERY_USER_TOGGLE, "🎯 Card Mastery", default=False),
     JobConfig(UIField.CARD_UPGRADE_USER_TOGGLE, "⬆️ Upgrade cards", default=False),
 ]
 

--- a/pyclashbot/interface/config.py
+++ b/pyclashbot/interface/config.py
@@ -10,6 +10,8 @@ from pyclashbot.interface.enums import (
     BOT_STAT_LABELS,
     COLLECTION_STAT_FIELDS,
     COLLECTION_STAT_LABELS,
+    WIN_RATE_STAT_FIELDS,
+    WIN_RATE_STAT_LABELS,
     BotStatField,
     StatField,
     UIField,
@@ -34,6 +36,7 @@ class JobConfig:
     title: str
     default: bool = False
     extras: dict[UIField, ComboConfig] | None = None
+    primary: bool = False
 
 
 @dataclass
@@ -56,9 +59,12 @@ class ComboConfig:
     default: str | int = ""
     size: tuple[int, int] = (5, 1)
     label_size: tuple[int, int] = (6, 1)
+    tooltip: str = ""
 
 
 # Statistics Configuration
+WIN_RATE_STATS = [StatConfig(field, WIN_RATE_STAT_LABELS[field]) for field in WIN_RATE_STAT_FIELDS]
+
 BATTLE_STATS = [StatConfig(field, BATTLE_STAT_LABELS[field]) for field in BATTLE_STAT_FIELDS]
 
 COLLECTION_STATS = [StatConfig(field, COLLECTION_STAT_LABELS[field]) for field in COLLECTION_STAT_FIELDS]
@@ -70,41 +76,43 @@ BOT_STATS = [
 
 # Job Configuration
 JOBS = [
-    JobConfig(UIField.CLASSIC_1V1_USER_TOGGLE, "Classic 1v1 battles", default=False),
-    JobConfig(UIField.CLASSIC_2V2_USER_TOGGLE, "Classic 2v2 battles", default=False),
-    JobConfig(UIField.TROPHY_ROAD_USER_TOGGLE, "Trophy Road battles", default=True),
+    JobConfig(UIField.CLASSIC_1V1_USER_TOGGLE, "⚔️ Classic 1v1", default=False, primary=True),
+    JobConfig(UIField.CLASSIC_2V2_USER_TOGGLE, "👥 Classic 2v2", default=False, primary=True),
+    JobConfig(UIField.TROPHY_ROAD_USER_TOGGLE, "🏆 Trophy Road", default=True, primary=True),
     JobConfig(
         UIField.RANDOM_DECKS_USER_TOGGLE,
-        "Random decks",
+        "🎲 Randomize deck",
         default=False,
         extras={
             UIField.DECK_NUMBER_SELECTION: ComboConfig(
                 key=UIField.DECK_NUMBER_SELECTION,
-                label="Deck #",
+                label="Deck slot",
                 values=[1, 2, 3, 4, 5],
                 default=2,
                 label_size=(10, 1),
+                tooltip="Deck slot (1-5) to use when randomizing",
             )
         },
     ),
     JobConfig(
         UIField.CYCLE_DECKS_USER_TOGGLE,
-        "Cycle decks",
+        "♻️ Cycle decks",
         default=False,
         extras={
             UIField.MAX_DECK_SELECTION: ComboConfig(
                 key=UIField.MAX_DECK_SELECTION,
-                label="Decks to Cycle:",
+                label="Decks to cycle",
                 values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                 default=2,
                 label_size=(15, 1),
+                tooltip="Number of deck slots to rotate through",
             )
         },
     ),
-    JobConfig(UIField.RANDOM_PLAYS_USER_TOGGLE, "Random plays", default=False),
-    JobConfig(UIField.DISABLE_WIN_TRACK_TOGGLE, "Skip win/loss check", default=False),
-    JobConfig(UIField.CARD_MASTERY_USER_TOGGLE, "Card Masteries", default=False),
-    JobConfig(UIField.CARD_UPGRADE_USER_TOGGLE, "Upgrade Cards", default=False),
+    JobConfig(UIField.RANDOM_PLAYS_USER_TOGGLE, "❔ Random card plays", default=False),
+    JobConfig(UIField.DISABLE_WIN_TRACK_TOGGLE, "⏭️ Skip win/loss tracking", default=False),
+    JobConfig(UIField.CARD_MASTERY_USER_TOGGLE, "🎯 Card mastery", default=False),
+    JobConfig(UIField.CARD_UPGRADE_USER_TOGGLE, "⬆️ Upgrade cards", default=False),
 ]
 
 # Emulator Settings Configuration
@@ -122,8 +130,8 @@ BLUESTACKS_SETTINGS = [
 ]
 
 EMULATOR_CHOICE = [
-    RadioConfig(UIField.MEMU_EMULATOR_TOGGLE, "Memu", "emulator_type_radio", default=True),
-    RadioConfig(UIField.GOOGLE_PLAY_EMULATOR_TOGGLE, "Google Play", "emulator_type_radio"),
+    RadioConfig(UIField.MEMU_EMULATOR_TOGGLE, "MEmu", "emulator_type_radio", default=True),
+    RadioConfig(UIField.GOOGLE_PLAY_EMULATOR_TOGGLE, "Google Play Games", "emulator_type_radio"),
     RadioConfig(UIField.BLUESTACKS_EMULATOR_TOGGLE, "BlueStacks 5", "emulator_type_radio"),
 ]
 

--- a/pyclashbot/interface/enums.py
+++ b/pyclashbot/interface/enums.py
@@ -81,9 +81,9 @@ BATTLE_STAT_LABELS: dict[StatField, str] = {
 BATTLE_STAT_FIELDS: tuple[StatField, ...] = tuple(BATTLE_STAT_LABELS.keys())
 
 COLLECTION_STAT_LABELS: dict[StatField, str] = {
-    StatField.CARD_MASTERY_REWARD_COLLECTIONS: "Mastery rewards",
+    StatField.CARD_MASTERY_REWARD_COLLECTIONS: "Card Mastery rewards",
     StatField.UPGRADES: "Card upgrades",
-    StatField.WAR_CHEST_COLLECTS: "War chests",
+    StatField.WAR_CHEST_COLLECTS: "War Chests",
 }
 
 COLLECTION_STAT_FIELDS: tuple[StatField, ...] = tuple(COLLECTION_STAT_LABELS.keys())

--- a/pyclashbot/interface/enums.py
+++ b/pyclashbot/interface/enums.py
@@ -62,29 +62,34 @@ class UIField(StrEnum):
     ADB_SERIAL = "adb_serial"
 
 
+WIN_RATE_STAT_LABELS: dict[StatField, str] = {
+    StatField.WINS: "Wins",
+    StatField.LOSSES: "Losses",
+}
+
+WIN_RATE_STAT_FIELDS: tuple[StatField, ...] = tuple(WIN_RATE_STAT_LABELS.keys())
+
 BATTLE_STAT_LABELS: dict[StatField, str] = {
-    StatField.WINS: "Win",
-    StatField.LOSSES: "Loss",
-    StatField.CARDS_PLAYED: "Moves",
-    StatField.CLASSIC_1V1_FIGHTS: "Classic 1v1s",
-    StatField.CLASSIC_2V2_FIGHTS: "Classic 2v2s",
-    StatField.TROPHY_ROAD_1V1_FIGHTS: "Trophy Road 1v1s",
-    StatField.CARD_RANDOMIZATIONS: "Decks Randomized",
-    StatField.CARD_CYCLES: "Decks Cycled",
+    StatField.CARDS_PLAYED: "Cards played",
+    StatField.CLASSIC_1V1_FIGHTS: "Classic 1v1",
+    StatField.CLASSIC_2V2_FIGHTS: "Classic 2v2",
+    StatField.TROPHY_ROAD_1V1_FIGHTS: "Trophy Road",
+    StatField.CARD_RANDOMIZATIONS: "Decks randomized",
+    StatField.CARD_CYCLES: "Decks cycled",
 }
 
 BATTLE_STAT_FIELDS: tuple[StatField, ...] = tuple(BATTLE_STAT_LABELS.keys())
 
 COLLECTION_STAT_LABELS: dict[StatField, str] = {
-    StatField.CARD_MASTERY_REWARD_COLLECTIONS: "Masteries",
-    StatField.UPGRADES: "Upgrades",
-    StatField.WAR_CHEST_COLLECTS: "War Chests",
+    StatField.CARD_MASTERY_REWARD_COLLECTIONS: "Mastery rewards",
+    StatField.UPGRADES: "Card upgrades",
+    StatField.WAR_CHEST_COLLECTS: "War chests",
 }
 
 COLLECTION_STAT_FIELDS: tuple[StatField, ...] = tuple(COLLECTION_STAT_LABELS.keys())
 
 BOT_STAT_LABELS: dict[BotStatField, str] = {
-    BotStatField.RESTARTS_AFTER_FAILURE: "Bot Failures",
+    BotStatField.RESTARTS_AFTER_FAILURE: "Recovery restarts",
     BotStatField.TIME_SINCE_START: "Runtime",
 }
 

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -607,7 +607,7 @@ class PyClashBotUI(ttk.Window):
         left.rowconfigure(0, weight=0)
         left.rowconfigure(1, weight=1)
 
-        gauge_frame = ttk.Labelframe(left, text="Win rate", padding=8)
+        gauge_frame = ttk.Labelframe(left, text="Win Rate", padding=8)
         gauge_frame.grid(row=0, column=0, sticky="ew")
         gauge_frame.columnconfigure(0, weight=1)
 
@@ -626,7 +626,7 @@ class PyClashBotUI(ttk.Window):
             ttk.Label(win_loss_frame, textvariable=var, foreground="#00aaff").grid(row=row, column=1, sticky="e")
             self.stat_labels[field] = var
 
-        battle_frame = ttk.Labelframe(left, text="Battle stats", padding=(10, 4, 10, 10))
+        battle_frame = ttk.Labelframe(left, text="Battle Stats", padding=(10, 4, 10, 10))
         battle_frame.grid(row=1, column=0, sticky="nsew", pady=(8, 0))
         battle_frame.columnconfigure(0, weight=1)
         battle_frame.rowconfigure(0, weight=1)
@@ -666,7 +666,7 @@ class PyClashBotUI(ttk.Window):
         right.rowconfigure(0, weight=0)
         right.rowconfigure(1, weight=1)
 
-        collection_frame = ttk.Labelframe(right, text="Collection stats", padding=10)
+        collection_frame = ttk.Labelframe(right, text="Collection Stats", padding=10)
         collection_frame.grid(row=0, column=0, sticky="ew")
         collection_frame.columnconfigure(1, weight=1)
         for row, field in enumerate(COLLECTION_STAT_FIELDS):
@@ -678,7 +678,7 @@ class PyClashBotUI(ttk.Window):
             ttk.Label(collection_frame, textvariable=var, foreground="#00aaff").grid(row=row, column=1, sticky="e")
             self.stat_labels[field] = var
 
-        bot_frame = ttk.Labelframe(right, text="Bot stats", padding=10)
+        bot_frame = ttk.Labelframe(right, text="Bot Stats", padding=10)
         bot_frame.grid(row=1, column=0, sticky="nsew", pady=(8, 0))
         bot_frame.columnconfigure(1, weight=1)
         self.bot_labels = {
@@ -719,7 +719,7 @@ class PyClashBotUI(ttk.Window):
 
         discord_checkbox = ttk.Checkbutton(
             data_frame,
-            text="Discord rich presence",
+            text="Discord Rich Presence",
             variable=self.discord_rpc_var,
             bootstyle="round-toggle",
             command=self._notify_config_change,

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -24,12 +24,14 @@ from pyclashbot.interface.enums import (
     BOT_STAT_LABELS,
     COLLECTION_STAT_FIELDS,
     COLLECTION_STAT_LABELS,
+    WIN_RATE_STAT_FIELDS,
+    WIN_RATE_STAT_LABELS,
     BotStatField,
     DerivedStatField,
     StatField,
     UIField,
 )
-from pyclashbot.interface.widgets import DualRingGauge
+from pyclashbot.interface.widgets import DualRingGauge, ScrollableFrame
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -176,7 +178,8 @@ class PyClashBotUI(ttk.Window):
             self._suspend_traces -= 1
 
         if theme_value is not None:
-            self._apply_theme(theme_value)
+            # Defer theme apply so combobox popdown widgets exist (avoids TclError on macOS).
+            self.after_idle(lambda t=theme_value: self._apply_theme(t))
 
         if UIField.DISCORD_RPC_TOGGLE.value in values:
             self.discord_rpc_var.set(bool(values[UIField.DISCORD_RPC_TOGGLE.value]))
@@ -191,7 +194,7 @@ class PyClashBotUI(ttk.Window):
         elif state == "running":
             self.main_btn.configure(text="Stop", bootstyle="danger", state=tk.NORMAL)
         elif state == "stopping":
-            self.main_btn.configure(text="Force Stop", bootstyle="warning", state=tk.NORMAL)
+            self.main_btn.configure(text="Force stop", bootstyle="warning", state=tk.NORMAL)
 
         # Disable/enable config widgets based on running state
         running = state in ("running", "stopping")
@@ -349,7 +352,6 @@ class PyClashBotUI(ttk.Window):
         frame.columnconfigure(1, weight=1)
 
         job_defaults = {job.key: job.default for job in JOBS}
-        jobs_by_key = {job.key: job for job in JOBS}
         self.jobs_vars: dict[UIField, ttk.BooleanVar] = {}
 
         checkbox_width = 25
@@ -377,93 +379,50 @@ class PyClashBotUI(ttk.Window):
         primary_bootstyle = "warning-outline-toolbutton"
         secondary_bootstyle = "info-outline-toolbutton"
 
-        add_job_checkbox(
-            UIField.CLASSIC_1V1_USER_TOGGLE,
-            "⚔️ Classic 1v1 battles",
-            0,
-            primary_bootstyle,
-        )
-        add_job_checkbox(
-            UIField.CLASSIC_2V2_USER_TOGGLE,
-            "👥 Classic 2v2 battles",
-            1,
-            primary_bootstyle,
-        )
-        add_job_checkbox(
-            UIField.TROPHY_ROAD_USER_TOGGLE,
-            "🏆 Trophy Road battles",
-            2,
-            primary_bootstyle,
-        )
+        for row_index, job in enumerate(JOBS):
+            bootstyle = primary_bootstyle if job.primary else secondary_bootstyle
 
-        random_job = jobs_by_key[UIField.RANDOM_DECKS_USER_TOGGLE]
-        deck_config: ComboConfig = random_job.extras[UIField.DECK_NUMBER_SELECTION]
-        self.jobs_vars[UIField.RANDOM_DECKS_USER_TOGGLE] = ttk.BooleanVar(value=random_job.default)
-        random_checkbox = ttk.Checkbutton(
-            frame,
-            text="🎲 Randomize Deck",
-            variable=self.jobs_vars[UIField.RANDOM_DECKS_USER_TOGGLE],
-            bootstyle=secondary_bootstyle,
-            command=self._notify_config_change,
-            width=checkbox_width,
-        )
-        random_checkbox.grid(row=3, column=0, sticky="w", pady=2)
-        self._trace_variable(self.jobs_vars[UIField.RANDOM_DECKS_USER_TOGGLE])
-        self._register_config_widget(UIField.RANDOM_DECKS_USER_TOGGLE.value, random_checkbox)
+            if job.extras:
+                combo_config = next(iter(job.extras.values()))
+                combo_field = combo_config.key
+                self.jobs_vars[job.key] = ttk.BooleanVar(value=job.default)
+                checkbox = ttk.Checkbutton(
+                    frame,
+                    text=job.title,
+                    variable=self.jobs_vars[job.key],
+                    bootstyle=bootstyle,
+                    command=self._notify_config_change,
+                    width=checkbox_width,
+                )
+                checkbox.grid(row=row_index, column=0, sticky="w", pady=2)
+                self._trace_variable(self.jobs_vars[job.key])
+                self._register_config_widget(job.key.value, checkbox)
 
-        deck_info = ttk.Label(frame, text="ⓘ", bootstyle="info")
-        deck_info.grid(row=3, column=2, sticky="e", padx=(0, 2))
-        ToolTip(deck_info, "Deck Number to use for Randomization")
-        self.deck_var = ttk.StringVar(value=str(deck_config.default))
-        self.deck_spin = ttk.Spinbox(
-            frame,
-            from_=min(deck_config.values),
-            to=max(deck_config.values),
-            width=6,
-            textvariable=self.deck_var,
-            command=self._notify_config_change,
-            state=READONLY,
-        )
-        self.deck_spin.grid(row=3, column=3, sticky="e")
-        self._trace_variable(self.deck_var)
-        self._register_config_widget(UIField.DECK_NUMBER_SELECTION.value, self.deck_spin)
+                info_label = ttk.Label(frame, text="ⓘ", bootstyle="info")
+                info_label.grid(row=row_index, column=2, sticky="e", padx=(0, 2))
+                if combo_config.tooltip:
+                    ToolTip(info_label, combo_config.tooltip)
 
-        cycle_job = jobs_by_key[UIField.CYCLE_DECKS_USER_TOGGLE]
-        max_config: ComboConfig = cycle_job.extras[UIField.MAX_DECK_SELECTION]
-        self.jobs_vars[UIField.CYCLE_DECKS_USER_TOGGLE] = ttk.BooleanVar(value=cycle_job.default)
-        cycle_checkbox = ttk.Checkbutton(
-            frame,
-            text="♻️ Cycle decks",
-            variable=self.jobs_vars[UIField.CYCLE_DECKS_USER_TOGGLE],
-            bootstyle=secondary_bootstyle,
-            command=self._notify_config_change,
-            width=checkbox_width,
-        )
-        cycle_checkbox.grid(row=4, column=0, sticky="w", pady=2)
-        self._trace_variable(self.jobs_vars[UIField.CYCLE_DECKS_USER_TOGGLE])
-        self._register_config_widget(UIField.CYCLE_DECKS_USER_TOGGLE.value, cycle_checkbox)
+                spin_var = ttk.StringVar(value=str(combo_config.default))
+                spinbox = ttk.Spinbox(
+                    frame,
+                    from_=min(combo_config.values),
+                    to=max(combo_config.values),
+                    width=6,
+                    textvariable=spin_var,
+                    command=self._notify_config_change,
+                    state=READONLY,
+                )
+                spinbox.grid(row=row_index, column=3, sticky="e")
+                self._trace_variable(spin_var)
+                self._register_config_widget(combo_field.value, spinbox)
 
-        max_deck_info = ttk.Label(frame, text="ⓘ", bootstyle="info")
-        max_deck_info.grid(row=4, column=2, sticky="e", padx=(0, 2))
-        ToolTip(max_deck_info, "Number of decks to cycle through")
-        self.max_deck_var = ttk.StringVar(value=str(max_config.default))
-        self.max_deck_spin = ttk.Spinbox(
-            frame,
-            from_=min(max_config.values),
-            to=max(max_config.values),
-            width=6,
-            textvariable=self.max_deck_var,
-            command=self._notify_config_change,
-            state=READONLY,
-        )
-        self.max_deck_spin.grid(row=4, column=3, sticky="e")
-        self._trace_variable(self.max_deck_var)
-        self._register_config_widget(UIField.MAX_DECK_SELECTION.value, self.max_deck_spin)
-
-        add_job_checkbox(UIField.RANDOM_PLAYS_USER_TOGGLE, "❔ Random plays", 5, secondary_bootstyle)
-        add_job_checkbox(UIField.DISABLE_WIN_TRACK_TOGGLE, "⏭️ Skip win/loss check", 6, secondary_bootstyle)
-        add_job_checkbox(UIField.CARD_MASTERY_USER_TOGGLE, "🎯 Card Masteries", 7, secondary_bootstyle)
-        add_job_checkbox(UIField.CARD_UPGRADE_USER_TOGGLE, "⬆️ Upgrade Cards", 8, secondary_bootstyle)
+                if combo_field == UIField.DECK_NUMBER_SELECTION:
+                    self.deck_var = spin_var
+                elif combo_field == UIField.MAX_DECK_SELECTION:
+                    self.max_deck_var = spin_var
+            else:
+                add_job_checkbox(job.key, job.title, row_index, bootstyle)
 
     def _create_emulator_tab(self) -> None:
         # Main container frame for the tab
@@ -473,7 +432,7 @@ class PyClashBotUI(ttk.Window):
         # Emulator Selection Dropdown
         selection_frame = ttk.Frame(container)
         selection_frame.pack(fill=X, pady=(0, 10))
-        ttk.Label(selection_frame, text="Select Emulator:").pack(side=LEFT, padx=(0, 5))
+        ttk.Label(selection_frame, text="Select emulator:").pack(side=LEFT, padx=(0, 5))
 
         available_emulators = get_available_emulators()
         default_emulator = available_emulators[0] if available_emulators else EmulatorType.ADB
@@ -527,7 +486,7 @@ class PyClashBotUI(ttk.Window):
         self._update_advanced_settings_visibility(self.emulator_var.get())
 
     def _create_google_play_settings(self, parent_frame: ttk.Frame) -> None:
-        frame = ttk.Labelframe(parent_frame, text="Google Play Options", padding=10)
+        frame = ttk.Labelframe(parent_frame, text="Google Play Games options", padding=10)
         frame.pack(fill="x", padx=5, pady=5)
 
         left_keys = GOOGLE_PLAY_SETTINGS[:4]
@@ -540,7 +499,7 @@ class PyClashBotUI(ttk.Window):
             self._add_google_play_row(frame, row, 3, config)
 
     def _create_memu_settings(self, parent_frame: ttk.Frame) -> None:
-        self.memu_advanced_frame = ttk.Labelframe(parent_frame, text="Render Mode", padding=10)
+        self.memu_advanced_frame = ttk.Labelframe(parent_frame, text="Render mode", padding=10)
         self.memu_advanced_frame.pack_forget()
 
         self.memu_render_var = ttk.StringVar(value="DirectX")
@@ -557,7 +516,7 @@ class PyClashBotUI(ttk.Window):
             self._register_config_widget(config.key.value, rb)
 
     def _create_bluestacks_settings(self, parent_frame: ttk.Frame) -> None:
-        self.bluestacks_advanced_frame = ttk.Labelframe(parent_frame, text="Render Mode", padding=10)
+        self.bluestacks_advanced_frame = ttk.Labelframe(parent_frame, text="Render mode", padding=10)
         self.bluestacks_advanced_frame.pack_forget()
 
         self.bs_render_var = ttk.StringVar(value="DirectX")
@@ -580,7 +539,7 @@ class PyClashBotUI(ttk.Window):
 
     def _create_adb_tab(self, parent_frame: ttk.Frame) -> None:
         """Create the widgets for the ADB Device settings tab."""
-        frame = ttk.Labelframe(parent_frame, text="Device Settings", padding=10)
+        frame = ttk.Labelframe(parent_frame, text="Device settings", padding=10)
         frame.pack(fill="x", padx=5, pady=5)
 
         # --- Row 1: Serial Input ---
@@ -588,7 +547,7 @@ class PyClashBotUI(ttk.Window):
         row1.pack(fill="x", pady=(0, 5))
         row1.columnconfigure(1, weight=1)
 
-        ttk.Label(row1, text="Device Serial:").grid(row=0, column=0, padx=(0, 5), sticky="w")
+        ttk.Label(row1, text="Device serial:").grid(row=0, column=0, padx=(0, 5), sticky="w")
 
         self.adb_serial_var = ttk.StringVar(value="")
         self.adb_serial_combo = ttk.Combobox(
@@ -622,68 +581,94 @@ class PyClashBotUI(ttk.Window):
         self.adb_restart_btn.pack(fill=X, pady=(0, 3))
         self._register_config_widget("adb_restart_btn", self.adb_restart_btn)
 
-        self.adb_set_size_btn = ttk.Button(row_buttons_action, text="Set Size & Density")
+        self.adb_set_size_btn = ttk.Button(row_buttons_action, text="Set size & density")
         self.adb_set_size_btn.pack(fill=X, pady=3)
         self._register_config_widget("adb_set_size_btn", self.adb_set_size_btn)
 
-        self.adb_reset_size_btn = ttk.Button(row_buttons_action, text="Reset Size & Density")
+        self.adb_reset_size_btn = ttk.Button(row_buttons_action, text="Reset size & density")
         self.adb_reset_size_btn.pack(fill=X, pady=(3, 0))
         self._register_config_widget("adb_reset_size_btn", self.adb_reset_size_btn)
 
-        ToolTip(self.adb_set_size_btn, "Sets screen to 419x633 and density to 160")
-        ToolTip(self.adb_reset_size_btn, "Resets screen size and density to device defaults")
+        ToolTip(self.adb_set_size_btn, "Set screen to 419x633 and density to 160")
+        ToolTip(self.adb_reset_size_btn, "Reset screen size and density to device defaults")
 
     def _create_stats_tab(self) -> None:
         container = ttk.Frame(self.stats_tab, padding=10)
         container.pack(fill=BOTH, expand=YES)
-        container.columnconfigure(0, weight=1)
-        container.columnconfigure(1, weight=1)
+        container.columnconfigure(0, weight=1, uniform="stats_cols")
+        container.columnconfigure(1, weight=1, uniform="stats_cols")
         container.rowconfigure(0, weight=1)
+
+        self.stat_labels: dict[StatField, ttk.StringVar] = {}
+
         left = ttk.Frame(container)
-        left.grid(row=0, column=0, sticky="nsew", padx=(0, 8))
+        left.grid(row=0, column=0, sticky="nsew", padx=(0, 5))
         left.columnconfigure(0, weight=1)
+        left.rowconfigure(0, weight=0)
         left.rowconfigure(1, weight=1)
 
-        gauge_frame = ttk.Labelframe(left, text="Win Rate", padding=10)
-        gauge_frame.pack(fill=X)
-        self.win_gauge = DualRingGauge(gauge_frame, diameter=120, thickness=12, text_color="#00aaff")
-        self.win_gauge.pack(anchor="center")
+        gauge_frame = ttk.Labelframe(left, text="Win rate", padding=8)
+        gauge_frame.grid(row=0, column=0, sticky="ew")
+        gauge_frame.columnconfigure(0, weight=1)
 
-        battle_frame = ttk.Labelframe(left, text="Battle Stats", padding=10)
-        battle_frame.pack(fill=BOTH, expand=YES, pady=(8, 0))
-        self.stat_labels: dict[StatField, ttk.StringVar] = {}
-        for row, field in enumerate(BATTLE_STAT_FIELDS):
-            title = BATTLE_STAT_LABELS[field]
-            label = ttk.Label(battle_frame, text=title)
+        self.win_gauge = DualRingGauge(gauge_frame, diameter=80, thickness=10, text_color="#00aaff")
+        self.win_gauge.grid(row=0, column=0, pady=(0, 6))
+
+        win_loss_frame = ttk.Frame(gauge_frame)
+        win_loss_frame.grid(row=1, column=0, sticky="ew")
+        win_loss_frame.columnconfigure(1, weight=1)
+        for row, field in enumerate(WIN_RATE_STAT_FIELDS):
+            title = WIN_RATE_STAT_LABELS[field]
+            label = ttk.Label(win_loss_frame, text=f"{title}:")
             label.grid(row=row, column=0, sticky="w")
             self._theme_labels.append(label)
             var = ttk.StringVar(value="0")
-            ttk.Label(battle_frame, textvariable=var, foreground="#00aaff").grid(row=row, column=1, sticky="e")
+            ttk.Label(win_loss_frame, textvariable=var, foreground="#00aaff").grid(row=row, column=1, sticky="e")
             self.stat_labels[field] = var
 
-        # Add win streak stats
-        ttk.Separator(battle_frame, orient="horizontal").grid(
+        battle_frame = ttk.Labelframe(left, text="Battle stats", padding=(10, 4, 10, 10))
+        battle_frame.grid(row=1, column=0, sticky="nsew", pady=(8, 0))
+        battle_frame.columnconfigure(0, weight=1)
+        battle_frame.rowconfigure(0, weight=1)
+
+        battle_scroll = ScrollableFrame(battle_frame)
+        battle_scroll.grid(row=0, column=0, sticky="nsew")
+        battle_body = battle_scroll.inner
+        battle_body.columnconfigure(1, weight=1)
+
+        for row, field in enumerate(BATTLE_STAT_FIELDS):
+            title = BATTLE_STAT_LABELS[field]
+            label = ttk.Label(battle_body, text=title)
+            label.grid(row=row, column=0, sticky="w")
+            self._theme_labels.append(label)
+            var = ttk.StringVar(value="0")
+            ttk.Label(battle_body, textvariable=var, foreground="#00aaff").grid(row=row, column=1, sticky="e")
+            self.stat_labels[field] = var
+
+        ttk.Separator(battle_body, orient="horizontal").grid(
             row=len(BATTLE_STAT_FIELDS), column=0, columnspan=2, sticky="ew", pady=(8, 4)
         )
         streak_row = len(BATTLE_STAT_FIELDS) + 1
-        ttk.Label(battle_frame, text="Current Streak:").grid(row=streak_row, column=0, sticky="w")
+        ttk.Label(battle_body, text="Current streak:").grid(row=streak_row, column=0, sticky="w")
         self.current_streak_var = ttk.StringVar(value="0")
-        ttk.Label(battle_frame, textvariable=self.current_streak_var, foreground="#00aaff").grid(
+        ttk.Label(battle_body, textvariable=self.current_streak_var, foreground="#00aaff").grid(
             row=streak_row, column=1, sticky="e"
         )
-        ttk.Label(battle_frame, text="Best Streak:").grid(row=streak_row + 1, column=0, sticky="w")
+        ttk.Label(battle_body, text="Best streak:").grid(row=streak_row + 1, column=0, sticky="w")
         self.best_streak_var = ttk.StringVar(value="0")
-        ttk.Label(battle_frame, textvariable=self.best_streak_var, foreground="#00aaff").grid(
+        ttk.Label(battle_body, textvariable=self.best_streak_var, foreground="#00aaff").grid(
             row=streak_row + 1, column=1, sticky="e"
         )
 
         right = ttk.Frame(container)
-        right.grid(row=0, column=1, sticky="nsew")
+        right.grid(row=0, column=1, sticky="nsew", padx=(5, 0))
         right.columnconfigure(0, weight=1)
+        right.rowconfigure(0, weight=0)
         right.rowconfigure(1, weight=1)
 
-        collection_frame = ttk.Labelframe(right, text="Collection Stats", padding=10)
-        collection_frame.pack(fill=X)
+        collection_frame = ttk.Labelframe(right, text="Collection stats", padding=10)
+        collection_frame.grid(row=0, column=0, sticky="ew")
+        collection_frame.columnconfigure(1, weight=1)
         for row, field in enumerate(COLLECTION_STAT_FIELDS):
             title = COLLECTION_STAT_LABELS[field]
             label = ttk.Label(collection_frame, text=title)
@@ -693,8 +678,9 @@ class PyClashBotUI(ttk.Window):
             ttk.Label(collection_frame, textvariable=var, foreground="#00aaff").grid(row=row, column=1, sticky="e")
             self.stat_labels[field] = var
 
-        bot_frame = ttk.Labelframe(right, text="Bot Stats", padding=10)
-        bot_frame.pack(fill=BOTH, expand=YES, pady=(8, 0))
+        bot_frame = ttk.Labelframe(right, text="Bot stats", padding=10)
+        bot_frame.grid(row=1, column=0, sticky="nsew", pady=(8, 0))
+        bot_frame.columnconfigure(1, weight=1)
         self.bot_labels = {
             BotStatField.RESTARTS_AFTER_FAILURE: ttk.StringVar(value="0"),
             BotStatField.TIME_SINCE_START: ttk.StringVar(value="00:00:00"),
@@ -714,7 +700,7 @@ class PyClashBotUI(ttk.Window):
         appearance = ttk.Labelframe(self.misc_tab, text="Appearance", padding=10)
         appearance.pack(padx=10, pady=10, anchor="n", fill="x")
 
-        ttk.Label(appearance, text="Select Theme:").pack(anchor="w", pady=(0, 4))
+        ttk.Label(appearance, text="Select theme:").pack(anchor="w", pady=(0, 4))
         self.theme_combo = ttk.Combobox(
             appearance,
             values=self._style.theme_names(),
@@ -728,12 +714,12 @@ class PyClashBotUI(ttk.Window):
         self._register_config_widget(UIField.THEME_NAME.value, self.theme_combo)
 
         ttk.Separator(self.misc_tab, orient="horizontal").pack(fill="x", padx=10, pady=(6, 0))
-        data_frame = ttk.Labelframe(self.misc_tab, text="Data Settings", padding=10)
+        data_frame = ttk.Labelframe(self.misc_tab, text="Data settings", padding=10)
         data_frame.pack(fill="x", padx=10, pady=10)
 
         discord_checkbox = ttk.Checkbutton(
             data_frame,
-            text="Discord Rich Presence",
+            text="Discord rich presence",
             variable=self.discord_rpc_var,
             bootstyle="round-toggle",
             command=self._notify_config_change,
@@ -744,13 +730,13 @@ class PyClashBotUI(ttk.Window):
 
         self.open_logs_btn = ttk.Button(
             data_frame,
-            text="Open Logs Folder",
+            text="Open logs folder",
             command=self._on_open_logs_clicked,
         )
         self.open_logs_btn.pack(fill="x", pady=(6, 0))
 
         ttk.Separator(self.misc_tab, orient="horizontal").pack(fill="x", padx=10, pady=(6, 0))
-        display_frame = ttk.Labelframe(self.misc_tab, text="Display Settings", padding=10)
+        display_frame = ttk.Labelframe(self.misc_tab, text="Display settings", padding=10)
         display_frame.pack(fill="x", padx=10, pady=10)
 
     def _register_config_widget(self, key: str, widget: tk.Widget) -> None:
@@ -811,7 +797,11 @@ class PyClashBotUI(ttk.Window):
                 self.theme_var.set(selected)
             finally:
                 self._suspend_traces -= 1
-        self._style.theme_use(selected)
+        try:
+            self._style.theme_use(selected)
+        except tk.TclError:
+            # Stale combobox popdown during theme refresh; safe to ignore on next user interaction.
+            return
         self._refresh_theme_colours()
 
     def _label_foreground(self) -> str:

--- a/pyclashbot/interface/widgets.py
+++ b/pyclashbot/interface/widgets.py
@@ -1,6 +1,86 @@
 from __future__ import annotations
 
+import sys
 import tkinter as tk
+
+import ttkbootstrap as ttk
+
+
+class ScrollableFrame(ttk.Frame):
+    """Vertical scroll area that shows a scrollbar only when content overflows."""
+
+    def __init__(self, master, **kwargs) -> None:
+        super().__init__(master, **kwargs)
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        self._canvas = tk.Canvas(self, highlightthickness=0, borderwidth=0)
+        self._scrollbar = ttk.Scrollbar(self, orient="vertical", command=self._canvas.yview)
+        self.inner = ttk.Frame(self._canvas)
+
+        self._inner_window = self._canvas.create_window((0, 0), window=self.inner, anchor="nw")
+        self._canvas.configure(yscrollcommand=self._scrollbar.set)
+
+        self._canvas.grid(row=0, column=0, sticky="nsew")
+        self._scrollbar.grid(row=0, column=1, sticky="ns")
+        self._scrollbar.grid_remove()
+
+        self.inner.bind("<Configure>", self._on_inner_configure)
+        self._canvas.bind("<Configure>", self._on_canvas_configure)
+        self._canvas.bind("<Enter>", self._bind_mousewheel)
+        self._canvas.bind("<Leave>", self._unbind_mousewheel)
+        self._mousewheel_bound = False
+
+    def _on_inner_configure(self, _event: tk.Event) -> None:
+        self._canvas.configure(scrollregion=self._canvas.bbox("all"))
+        self._update_scrollbar_visibility()
+
+    def _on_canvas_configure(self, event: tk.Event) -> None:
+        self._canvas.itemconfigure(self._inner_window, width=event.width)
+        self._update_scrollbar_visibility()
+
+    def _update_scrollbar_visibility(self) -> None:
+        self.update_idletasks()
+        canvas_height = self._canvas.winfo_height()
+        inner_height = self.inner.winfo_reqheight()
+        if inner_height > canvas_height:
+            self._scrollbar.grid(row=0, column=1, sticky="ns")
+        else:
+            self._scrollbar.grid_remove()
+            self._canvas.yview_moveto(0)
+
+    def _bind_mousewheel(self, _event: tk.Event) -> None:
+        if self._mousewheel_bound:
+            return
+        self._mousewheel_bound = True
+        if sys.platform == "darwin":
+            self._canvas.bind_all("<MouseWheel>", self._on_mousewheel)
+        else:
+            self._canvas.bind_all("<MouseWheel>", self._on_mousewheel)
+            self._canvas.bind_all("<Button-4>", self._on_mousewheel_linux_up)
+            self._canvas.bind_all("<Button-5>", self._on_mousewheel_linux_down)
+
+    def _unbind_mousewheel(self, _event: tk.Event) -> None:
+        if not self._mousewheel_bound:
+            return
+        self._mousewheel_bound = False
+        self._canvas.unbind_all("<MouseWheel>")
+        if sys.platform != "darwin":
+            self._canvas.unbind_all("<Button-4>")
+            self._canvas.unbind_all("<Button-5>")
+
+    def _on_mousewheel(self, event: tk.Event) -> None:
+        if sys.platform == "darwin":
+            delta = -1 * int(event.delta)
+        else:
+            delta = -1 * int(event.delta / 120)
+        self._canvas.yview_scroll(delta, "units")
+
+    def _on_mousewheel_linux_up(self, _event: tk.Event) -> None:
+        self._canvas.yview_scroll(-1, "units")
+
+    def _on_mousewheel_linux_down(self, _event: tk.Event) -> None:
+        self._canvas.yview_scroll(1, "units")
 
 
 class DualRingGauge(tk.Canvas):
@@ -49,12 +129,13 @@ class DualRingGauge(tk.Canvas):
         centre = self.winfo_reqwidth() // 2
         if self._text:
             self.delete(self._text)
+        label_size = 14 if self.diameter <= 80 else 16
         self._text = self.create_text(
             centre,
             centre,
             text="0%",
             fill=self.text_colour,
-            font=("-size", 16, "-weight", "bold"),
+            font=("-size", label_size, "-weight", "bold"),
         )
 
     def _draw_dynamic(


### PR DESCRIPTION
## Summary

- **Stats tab:** Smaller win-rate gauge (80px), scrollable battle stats when the window is short, equal-width left/right columns, wins/losses moved into the win rate panel.
- **UI copy:** Official Clash Royale proper nouns where applicable (Card Mastery, War Chests, Win Rate, Battle Stats, etc.); generic counters stay sentence case (e.g. cards played, card upgrades). Job checkbox text centralized in `config.py`.
- **Status log:** Card Mastery reward messages aligned with UI naming.
- **Startup:** Defer theme apply on load to avoid a ttkbootstrap combobox TclError on macOS.
- **Emulator label:** Display name updated to Google Play Games in the emulator picker.

## Test plan

- [x] `make lint`
- [x] `make dev` — Stats tab at full and small window sizes; Jobs/Emulator/Misc labels reviewed