### PR TITLE
refactor: consolidate state detection into state_detect.py

### DIFF
--- a/pyclashbot/bot/card_mastery_state.py
+++ b/pyclashbot/bot/card_mastery_state.py
@@ -1,18 +1,17 @@
 import time
 
 from pyclashbot.bot.nav import (
-    check_if_on_card_page,
-    check_if_on_clash_main_menu,
     get_to_card_page_from_clash_main,
     wait_for_clash_main_menu,
 )
-from pyclashbot.detection.image_rec import pixel_is_equal
+from pyclashbot.bot.state_detect import (
+    card_mastery_rewards_exist,
+    check_for_inventory_full_popup,
+    check_if_on_card_page,
+    check_if_on_clash_main_menu,
+)
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
-
-CARD_MASTERY_COORD = (340, 440)
-CARD_MASTERY_BGR = (95, 214, 251)
-PIXEL_TOLERANCE = 15
 
 
 def card_mastery_state(emulator, logger):
@@ -112,47 +111,6 @@ def card_mastery_rewards_exist_with_delay(emulator):
             return True
 
     return False
-
-
-def card_mastery_rewards_exist(emulator):
-    screenshot = emulator.screenshot()
-
-    x, y = CARD_MASTERY_COORD
-    pixel = screenshot[y][x]
-
-    return pixel_is_equal(pixel, CARD_MASTERY_BGR, PIXEL_TOLERANCE)
-
-
-def check_for_inventory_full_popup(emulator):
-    iar = emulator.screenshot()
-    pixels = [
-        iar[410][220],
-        iar[420][225],
-        iar[416][225],
-        iar[418][230],
-        iar[420][240],
-        iar[430][250],
-        iar[435][260],
-        iar[427][270],
-        iar[429][280],
-        iar[435][290],
-    ]
-    colors = [
-        [255, 187, 105],
-        [255, 187, 105],
-        [255, 187, 105],
-        [244, 233, 220],
-        [60, 52, 43],
-        [255, 175, 78],
-        [255, 175, 78],
-        [255, 255, 255],
-        [241, 165, 74],
-        [255, 175, 78],
-    ]
-    for i, c in enumerate(colors):
-        if not pixel_is_equal(c, pixels[i], tol=15):
-            return False
-    return True
 
 
 if __name__ == "__main__":

--- a/pyclashbot/bot/deck_cycle.py
+++ b/pyclashbot/bot/deck_cycle.py
@@ -4,17 +4,17 @@ Deck cycling and selection methods for py-clash-bot.
 
 import time
 
-from pyclashbot.bot.deck_utils import (
-    is_deck_full,
-    is_single_deck_layout_by_pixel,
-    randomize_and_check_deck,
-)
+from pyclashbot.bot.deck_utils import randomize_and_check_deck
 from pyclashbot.bot.nav import (
     DECK_TABS_REGION,
     _navigate_to_deck_selection,
-    check_if_on_clash_main_menu,
     return_to_clash_main_from_card_page,
     switch_deck_page,
+)
+from pyclashbot.bot.state_detect import (
+    check_if_on_clash_main_menu,
+    is_deck_full,
+    is_single_deck_layout_by_pixel,
 )
 from pyclashbot.detection.image_rec import find_image
 from pyclashbot.utils.cancellation import interruptible_sleep

--- a/pyclashbot/bot/deck_randomization.py
+++ b/pyclashbot/bot/deck_randomization.py
@@ -4,16 +4,16 @@ Deck randomization methods for py-clash-bot.
 
 import time
 
-from pyclashbot.bot.deck_utils import (
-    is_single_deck_layout_by_pixel,
-    randomize_and_check_deck,
-)
+from pyclashbot.bot.deck_utils import randomize_and_check_deck
 from pyclashbot.bot.nav import (
     DECK_TABS_REGION,
-    check_if_on_clash_main_menu,
     get_to_card_page_from_clash_main,
     return_to_clash_main_from_card_page,
     switch_deck_page,
+)
+from pyclashbot.bot.state_detect import (
+    check_if_on_clash_main_menu,
+    is_single_deck_layout_by_pixel,
 )
 from pyclashbot.detection.image_rec import find_image
 from pyclashbot.utils.cancellation import interruptible_sleep

--- a/pyclashbot/bot/deck_utils.py
+++ b/pyclashbot/bot/deck_utils.py
@@ -1,48 +1,14 @@
-import numpy
-
-from pyclashbot.detection.image_rec import pixel_is_equal
+from pyclashbot.bot.state_detect import is_deck_full, is_single_deck_layout_by_pixel
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
+
+# Re-export for backwards compatibility; new callers should import from state_detect.
+__all__ = ["is_deck_full", "is_single_deck_layout_by_pixel", "randomize_and_check_deck"]
 
 # --- Constants for UI element locations ---
 DECK_OPTIONS_BUTTON_COORDS = (53, 106)
 RANDOMIZE_DECK_BUTTON_COORDS = (125, 188)
 RANDOMIZE_DECK_CONFIRM_BUTTON_COORDS = (280, 390)
-
-
-def is_deck_full(emulator) -> bool:
-    iar = numpy.asarray(emulator.screenshot())
-    pixels = [
-        iar[172][43],
-        iar[172][130],
-        iar[172][216],
-        iar[172][302],
-        iar[310][43],
-        iar[311][130],
-        iar[309][216],
-        iar[309][302],
-    ]
-    valid_colors = [
-        [175, 5, 179],
-        [178, 5, 182],
-        [178, 5, 183],
-        [188, 2, 194],
-        [185, 4, 191],
-        [197, 2, 209],
-        [193, 2, 203],
-    ]
-    return all(any(pixel_is_equal(valid_color, p, tol=40) for valid_color in valid_colors) for p in pixels)
-
-
-def is_single_deck_layout_by_pixel(emulator) -> bool:
-    iar = numpy.asarray(emulator.screenshot())
-    pixel_coords = [(99, 165), (117, 166), (99, 313), (117, 313)]
-    expected_colors = [[141, 29, 0], [147, 34, 0], [145, 31, 4], [149, 34, 3]]
-    return all(
-        pixel_is_equal(expected, actual, tol=45)
-        for (x, y), expected in zip(pixel_coords, expected_colors)
-        for actual in [iar[y][x]]
-    )
 
 
 def randomize_and_check_deck(emulator, logger: Logger, deck_to_randomize: int) -> bool:

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -18,6 +18,7 @@ from pyclashbot.bot.nav import (
     wait_for_battle_start,
     wait_for_clash_main_menu,
 )
+from pyclashbot.bot.recorder import save_play, save_win_loss
 from pyclashbot.bot.state_detect import (
     check_if_battle_has_ended,
     check_if_in_battle,
@@ -25,7 +26,6 @@ from pyclashbot.bot.state_detect import (
     check_pixels_for_win_in_battle_log,
     count_elixer,
 )
-from pyclashbot.bot.recorder import save_play, save_win_loss
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
 
@@ -56,6 +56,8 @@ EMOTE_ICON_COORDS = [
     (243, 469),
     (308, 470),
 ]
+
+
 def do_fight_state(
     emulator,
     logger: Logger,

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -13,19 +13,19 @@ from pyclashbot.bot.card_detection import (
 )
 from pyclashbot.bot.nav import (
     check_for_in_battle_with_delay,
-    check_if_battle_has_ended,
-    check_if_in_battle,
-    check_if_on_clash_main_menu,
     get_to_activity_log,
     get_to_main_after_fight,
     wait_for_battle_start,
     wait_for_clash_main_menu,
 )
-from pyclashbot.bot.recorder import save_play, save_win_loss
-from pyclashbot.detection.image_rec import (
-    check_line_for_color,
-    pixel_is_equal,
+from pyclashbot.bot.state_detect import (
+    check_if_battle_has_ended,
+    check_if_in_battle,
+    check_if_on_clash_main_menu,
+    check_pixels_for_win_in_battle_log,
+    count_elixer,
 )
+from pyclashbot.bot.recorder import save_play, save_win_loss
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
 
@@ -56,21 +56,6 @@ EMOTE_ICON_COORDS = [
     (243, 469),
     (308, 470),
 ]
-ELIXIR_COORDS = [
-    [613, 149],
-    [613, 165],
-    [613, 188],
-    [613, 212],
-    [613, 240],
-    [613, 262],
-    [613, 287],
-    [613, 314],
-    [613, 339],
-    [613, 364],
-]
-ELIXIR_COLOR = [240, 137, 244]
-
-
 def do_fight_state(
     emulator,
     logger: Logger,
@@ -281,19 +266,6 @@ def wait_for_elixer(
     return True
 
 
-def count_elixer(emulator, elixer_count) -> bool:
-    """Method to check for 4 elixer during a battle"""
-    iar = emulator.screenshot()
-
-    if pixel_is_equal(
-        iar[ELIXIR_COORDS[elixer_count - 1][0], ELIXIR_COORDS[elixer_count - 1][1]],
-        ELIXIR_COLOR,
-        tol=65,
-    ):
-        return True
-    return False
-
-
 def end_fight_state(
     emulator,
     logger: Logger,
@@ -371,40 +343,6 @@ def check_if_previous_game_was_win(
     interruptible_sleep(2)
 
     return is_a_win
-
-
-def check_pixels_for_win_in_battle_log(emulator) -> bool:
-    """Method to check pixels that appear in the battle
-    log to determing if the previous game was a win
-    """
-    line1 = check_line_for_color(
-        emulator,
-        x_1=47,
-        y_1=135,
-        x_2=109,
-        y_2=154,
-        color=(255, 51, 102),
-    )
-    line2 = check_line_for_color(
-        emulator,
-        x_1=46,
-        y_1=152,
-        x_2=115,
-        y_2=137,
-        color=(255, 51, 102),
-    )
-    line3 = check_line_for_color(
-        emulator,
-        x_1=47,
-        y_1=144,
-        x_2=110,
-        y_2=147,
-        color=(255, 51, 102),
-    )
-
-    if line1 and line2 and line3:
-        return False
-    return True
 
 
 # main fight loops

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -4,7 +4,6 @@ from typing import Literal
 
 from pyclashbot.bot.constants import CLASH_MAIN_DEADSPACE_COORD as CLASH_MAIN_MENU_DEADSPACE_COORD
 from pyclashbot.bot.state_detect import (
-    check_for_post_battle_button,
     check_for_trophy_reward_menu,
     check_if_battle_mode_is_selected,
     check_if_in_battle,

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -3,13 +3,39 @@ import time
 from typing import Literal
 
 from pyclashbot.bot.constants import CLASH_MAIN_DEADSPACE_COORD as CLASH_MAIN_MENU_DEADSPACE_COORD
+from pyclashbot.bot.state_detect import (
+    check_for_post_battle_button,
+    check_for_trophy_reward_menu,
+    check_if_battle_mode_is_selected,
+    check_if_in_battle,
+    check_if_on_battle_log_page,
+    check_if_on_card_page,
+    check_if_on_clan_chat,
+    check_if_on_clash_main_burger_button_options_menu,
+    check_if_on_clash_main_menu,
+    check_if_on_shop,
+    check_if_on_social,
+)
 from pyclashbot.detection.image_rec import (
-    all_pixels_are_equal,
     find_image,
     pixel_is_equal,
 )
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
+
+# Re-export moved detectors so existing `from pyclashbot.bot.nav import check_if_*`
+# call sites keep working. New code should import from pyclashbot.bot.state_detect.
+__all__ = [
+    "check_if_battle_mode_is_selected",
+    "check_if_in_battle",
+    "check_if_on_battle_log_page",
+    "check_if_on_card_page",
+    "check_if_on_clan_chat",
+    "check_if_on_clash_main_burger_button_options_menu",
+    "check_if_on_clash_main_menu",
+    "check_if_on_shop",
+    "check_if_on_social",
+]
 
 CLASH_MAIN_OPTIONS_BURGER_BUTTON = (390, 62)
 BATTLE_LOG_BUTTON = (241, 43)
@@ -78,122 +104,6 @@ def check_for_in_battle_with_delay(emulator) -> bool:
     return False
 
 
-def check_if_in_battle(emulator):
-    iar_bgr = emulator.screenshot()
-    if iar_bgr is None:
-        return False
-
-    # Convert to RGB for easier reasoning about expected colors.
-    iar = iar_bgr[..., ::-1]
-
-    def get_pixel(y: int, x: int) -> list[int] | None:
-        if y >= iar.shape[0] or x >= iar.shape[1]:
-            return None
-        return iar[y][x].tolist()
-
-    def is_bright(pixel: list[int] | None, threshold: int = 180) -> bool:
-        if pixel is None:
-            return False
-        return all(channel >= threshold for channel in pixel) or (
-            150 <= pixel[0] <= 195 and 40 <= pixel[1] <= 60 and 40 <= pixel[2] <= 60
-        )
-
-    def is_filled_crown(pixel: list[int] | None) -> bool:
-        """Check if pixel is a gold/yellow filled crown or UI accent."""
-        if pixel is None:
-            return False
-        r, g, b = pixel
-        return r >= 170 and g >= 130 and b <= 140
-
-    def is_scoreboard_purple(pixel: list[int] | None) -> bool:
-        if pixel is None:
-            return False
-        r, g, b = pixel
-        return r >= 200 and b >= 200 and g <= 140
-
-    def check_mode(coords: list[tuple[int, int]]) -> bool:
-        pixels = [get_pixel(y, x) for y, x in coords]
-        # Allow one of the "bright" UI pixels to change (crowns filling, overlays,
-        # small rendering differences) while still requiring the purple scoreboard.
-        bright_required = max(1, len(coords) - 2)
-        bright_count = sum(1 for pixel in pixels[:-1] if is_bright(pixel) or is_filled_crown(pixel))
-        return bright_count >= bright_required and is_scoreboard_purple(pixels[-1])
-
-    # When the emote is closed these pixels are not considered bright:
-    # (533, 80) RGB=[157, 44, 44] and (532, 77) RGB=[187, 55, 55]
-    coords_1v1 = [(528, 49), (532, 77), (546, 52), (546, 77), (618, 115)]
-    coords_2v2 = [(534, 53), (533, 80), (548, 52), (548, 76), (615, 114)]
-
-    if check_mode(coords_1v1):
-        return True
-    if check_mode(coords_2v2):
-        return True
-
-    return False
-
-
-def check_for_post_battle_button(emulator) -> bool:
-    """Checks for the post-battle OK/Exit buttons (battle-end screen)."""
-    image = emulator.screenshot()
-    if image is None:
-        return False
-
-    if find_image(image, "ok_post_battle_button", tolerance=0.85) is not None:
-        return True
-
-    if find_image(image, "exit_battle_button", tolerance=0.9) is not None:
-        return True
-
-    return False
-
-
-def check_if_battle_has_ended(emulator) -> bool:
-    """Best-effort confirmation that a battle ended (avoid false positives mid-fight)."""
-    if check_if_on_clash_main_menu(emulator):
-        return True
-
-    if check_for_trophy_reward_menu(emulator):
-        return True
-
-    if check_for_post_battle_button(emulator):
-        return True
-
-    return False
-
-
-def check_for_trophy_reward_menu(emulator) -> bool:
-    iar = emulator.screenshot()
-
-    pixels = [
-        iar[592][172],
-        iar[617][180],
-        iar[607][190],
-        iar[603][200],
-        iar[596][210],
-        iar[593][220],
-        iar[600][230],
-        iar[610][235],
-        iar[623][246],
-    ]
-    colors = [
-        [255, 184, 68],
-        [255, 175, 78],
-        [255, 175, 78],
-        [248, 239, 227],
-        [255, 187, 104],
-        [255, 176, 79],
-        [255, 187, 104],
-        [255, 175, 78],
-        [253, 135, 39],
-    ]
-
-    for i, pixel in enumerate(pixels):
-        if not pixel_is_equal(pixel, colors[i], tol=25):
-            return False
-
-    return True
-
-
 def handle_trophy_reward_menu(
     emulator,
     logger: Logger,
@@ -246,78 +156,6 @@ def wait_for_clash_main_menu(emulator, logger: Logger, deadspace_click=True) -> 
     return True
 
 
-def check_if_on_clash_main_menu(emulator) -> bool:
-    """Checks if the user is on the clash main menu.
-    Returns True if on main menu, False if not.
-    """
-    image = emulator.screenshot()
-    pixels = [
-        image[14][209],  # white
-        image[14][325],  # white
-        image[19][298],  # yellow
-        image[17][399],  # green
-        image[581][261],  # green
-        image[584][166],  # bluegrey
-        image[621][166],  # bluegrey
-    ]
-
-    # google play colors
-    colors_1 = [
-        [255, 255, 255],
-        [255, 255, 255],
-        [53, 199, 233],
-        [25, 198, 65],
-        [138, 105, 71],
-        [139, 105, 72],
-        [155, 120, 82],
-    ]
-
-    # memu colors
-    colors_2 = [
-        [255, 255, 255],
-        [255, 255, 255],
-        [53, 200, 233],
-        [24, 199, 65],
-        [138, 105, 71],
-        [139, 105, 72],
-        [155, 120, 81],
-    ]
-
-    # post Clash Royale app update colors
-    colors_3 = [
-        [57, 151, 206],
-        [21, 148, 42],
-        [36, 17, 1],
-        [231, 190, 123],
-        [140, 105, 74],
-        [140, 105, 74],
-        [156, 121, 82],
-    ]
-
-    # print("{:^15} | {:^15} | {:^15}".format("Seen", "Google", "Memu"))
-    # for seen_pixel, google_play_color, memu_color in zip(pixels, colors_1, colors_2):
-    #     seen_pixel =str(seen_pixel[0])+ ' '+ str(seen_pixel[1])+ ' '+ str(seen_pixel[2])
-    #     google_play_color = (
-    #         str(google_play_color[0]) + ' ' +
-    #         str(google_play_color[1]) + ' ' +
-    #         str(google_play_color[2])
-    #     )
-    #     memu_color = str(memu_color[0]) + ' ' + str(memu_color[1]) + ' ' + str(memu_color[2])
-    #     print(
-    #         "{:^15} | {:^15} | {:^15}".format(seen_pixel, google_play_color, memu_color)
-    #     )
-
-    for colors in [colors_1, colors_2, colors_3]:
-        if all_pixels_are_equal(
-            pixels,
-            colors,
-            25,
-        ):
-            return True
-
-    return False
-
-
 def get_to_card_page_from_clash_main(
     emulator,
     logger: Logger,
@@ -348,62 +186,6 @@ def get_to_card_page_from_clash_main(
     logger.change_status(status="Made it to card page")
 
     return "good"
-
-
-def check_if_on_card_page(emulator) -> bool:
-    iar = emulator.screenshot()
-
-    pixels = [
-        iar[433][58],
-        iar[116][59],
-        iar[58][82],
-        iar[64][179],
-        iar[62][108],
-        iar[67][146],
-        iar[77][185],
-        iar[77][84],
-    ]
-
-    colors1 = [
-        [222, 0, 235],
-        [255, 255, 255],
-        [203, 137, 44],
-        [195, 126, 34],
-        [255, 255, 255],
-        [255, 255, 255],
-        [177, 103, 15],
-        [178, 104, 15],
-    ]
-
-    colors2 = [
-        [220, 0, 234],
-        [255, 255, 255],
-        [209, 68, 41],
-        [202, 64, 41],
-        [255, 255, 255],
-        [255, 255, 255],
-        [185, 52, 41],
-        [185, 52, 41],
-    ]
-
-    def pixel_to_string(pixel):
-        return f"[{pixel[0]},{pixel[1]},{pixel[2]}],"
-
-    # print("{:^17} {:^17} {:^17}".format("pixel", "color1", "color2"))
-    # for pixel, color1, color2 in zip(pixels, colors1, colors2):
-    #     print(
-    #         "{:^17} {:^17} {:^17}".format(
-    #             pixel_to_string(pixel), pixel_to_string(color1), pixel_to_string(color2)
-    #         )
-    #     )
-
-    if all_pixels_are_equal(pixels, colors1, tol=25):
-        return True
-
-    if all_pixels_are_equal(pixels, colors2, tol=25):
-        return True
-
-    return False
 
 
 def return_to_clash_main_from_card_page(emulator, logger: Logger) -> bool:
@@ -490,70 +272,6 @@ def wait_for_battle_log_page(
     return "good"
 
 
-def check_if_on_battle_log_page(emulator) -> bool:
-    iar = emulator.screenshot()
-
-    pixels = [
-        iar[72][160],
-        iar[71][187],
-        iar[71][197],
-        iar[72][231],
-        iar[73][258],
-        iar[64][366],
-        iar[79][365],
-        iar[70][365],
-        iar[62][92],
-        iar[77][316],
-    ]
-    colors = [
-        [255, 255, 255],
-        [255, 255, 255],
-        [255, 255, 255],
-        [255, 255, 255],
-        [255, 255, 255],
-        [147, 135, 254],
-        [38, 38, 240],
-        [255, 255, 255],
-        [138, 122, 115],
-        [124, 106, 99],
-    ]
-
-    for i, p in enumerate(pixels):
-        if not pixel_is_equal(p, colors[i], tol=25):
-            return False
-    return True
-
-
-def check_if_on_clash_main_burger_button_options_menu(emulator) -> bool:
-    iar = emulator.screenshot()
-    pixels = [
-        iar[42][256],
-        iar[41][275],
-        iar[41][282],
-        iar[42][293],
-        iar[44][325],
-        iar[32][239],
-        iar[34][336],
-        iar[50][248],
-        iar[49][336],
-    ]
-    colors = [
-        [255, 255, 255],
-        [255, 255, 255],
-        [255, 255, 255],
-        [255, 255, 254],
-        [255, 255, 255],
-        [255, 187, 105],
-        [255, 187, 105],
-        [255, 175, 78],
-        [255, 175, 78],
-    ]
-    for i, color in enumerate(colors):
-        if not pixel_is_equal(pixels[i], color, tol=25):
-            return False
-    return True
-
-
 def wait_for_clash_main_burger_button_options_menu(
     emulator,
     logger: Logger,
@@ -595,48 +313,6 @@ def wait_for_clash_main_burger_button_options_menu(
     return "good"
 
 
-def check_if_battle_mode_is_selected(emulator, mode: str):
-    """Checks if the given battle mode is selected on the clash main menu.
-
-    Args:
-        emulator: The emulator controller.
-        mode: The battle mode to check for.
-
-    Returns:
-        True if the mode is selected, False otherwise.
-    """
-    expected_mode_types = ["Classic 1v1", "Classic 2v2", "Trophy Road"]
-
-    # Check if the mode is valid
-    if mode not in expected_mode_types:
-        print(f'[!] Fatal error: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.')
-        return None
-
-    mode2folder = {
-        "Classic 1v1": "selected_1v1_on_main",
-        "Classic 2v2": "selected_2v2_on_main",
-        "Trophy Road": "selected_trophy_road_on_main",
-    }
-
-    look_folder = mode2folder[mode]
-
-    print(f"[DEBUG] Checking if {mode} is selected...")
-    print(f"[DEBUG] Looking in folder: {look_folder}")
-    print("[DEBUG] Subcrop: (270, 455, 350, 533)")
-
-    # find image on screen
-    coord = find_image(
-        emulator.screenshot(),
-        look_folder,
-        tolerance=0.9,
-        subcrop=(270, 455, 350, 533),
-    )
-
-    print(f"[DEBUG] Found at: {coord}")
-
-    return coord is not None
-
-
 def find_fight_mode_icon(emulator, mode: str):
     expected_mode_types = ["Classic 1v1", "Classic 2v2", "Trophy Road"]
 
@@ -654,11 +330,6 @@ def find_fight_mode_icon(emulator, mode: str):
     look_folder = mode2folder[mode]
 
     image = emulator.screenshot()
-
-    # os.makedirs('select_mode_images', exist_ok=True)
-    # file_name = f'{random.randint(0,100000)}.png'
-    # file_path = os.path.join('select_mode_images', file_name)
-    # cv2.imwrite(file_path, image)
 
     fight_mode_1v1_button_location = find_image(
         image,
@@ -740,74 +411,6 @@ PAGE_CARD = "card_page"
 PAGE_SHOP = "shop"
 PAGE_SOCIAL = "social"
 PAGE_CLAN_CHAT = "clan-chat"
-
-
-def check_if_on_shop(emulator) -> bool:
-    iar = emulator.screenshot()
-    pixels = [
-        iar[589][16],
-        iar[609][19],
-        iar[14][212],
-        iar[15][331],
-        iar[600][128],
-    ]
-    colors = [
-        [140, 107, 73],
-        [151, 116, 77],
-        [57, 160, 214],
-        [22, 186, 59],
-        [255, 225, 137],
-    ]
-    for i, p in enumerate(pixels):
-        if not pixel_is_equal(p, colors[i], tol=25):
-            return False
-    return True
-
-
-def check_if_on_social(emulator) -> bool:
-    iar = emulator.screenshot()
-    pixels = [
-        iar[601][218],
-        iar[577][342],
-        iar[620][299],
-    ]
-    colors = [
-        [255, 226, 138],
-        [142, 108, 75],
-        [155, 120, 82],
-    ]
-    for i, p in enumerate(pixels):
-        if not pixel_is_equal(p, colors[i], tol=25):
-            return False
-    return True
-
-
-def check_if_on_clan_chat(emulator) -> bool:
-    iar = emulator.screenshot()
-    pixels = [
-        iar[5][5],
-        iar[628][415],
-        iar[612][177],
-        iar[44][322],
-        iar[19][321],
-        iar[620][254],
-        iar[612][161],
-        iar[584][204],
-    ]
-    colors = [
-        [141, 85, 69],
-        [105, 85, 71],
-        [255, 175, 78],
-        [237, 215, 201],
-        [245, 231, 222],
-        [107, 86, 72],
-        [109, 87, 73],
-        [160, 128, 108],
-    ]
-    for i, p in enumerate(pixels):
-        if not pixel_is_equal(p, colors[i], tol=25):
-            return False
-    return True
 
 
 MAIN_PAGE_CHECKS = {
@@ -984,30 +587,4 @@ def get_to_main_after_fight(emulator, logger):
 
 
 if __name__ == "__main__":
-    # from pyclashbot.emulators.memu import MemuEmulatorController
-    # from pyclashbot.utils.logger import Logger
-    # import cv2
-    # import os
-
-    # print("Creating logger...")
-    # logger = Logger()
-
-    # print("Creating MEmu emulator controller in DEBUG mode (no restart)...")
-    # emulator = MemuEmulatorController(logger, render_mode="directx", debug_mode=True)
-
-    # # Save a screenshot for debugging
-    # print("\nSaving screenshot for debugging...")
-    # os.makedirs("debug_screenshots", exist_ok=True)
-    # screenshot = emulator.screenshot()
-    # cv2.imwrite("debug_screenshots/current_screen.png", screenshot)
-    # print(f"Screenshot saved to: debug_screenshots/current_screen.png")
-    # print(f"Screenshot size: {screenshot.shape}")
-
-    # print("\nTesting find_fight_mode_icon...")
-    # x = check_if_battle_mode_is_selected(emulator, "Classic 2v2")
-    # print(f"Result: Is Classic 2v2 selected? {x}")
-
-    # select_mode(emulator, "Classic 1v1")
-
-    # here matt if you want to test this and see debug info
     pass

--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -1,0 +1,569 @@
+"""Pure state-detection helpers.
+
+Every function here follows the same shape: take a screenshot, run a pixel or
+image comparison, return a bool. No clicks, no waits, no orchestration — those
+live in nav.py or the per-state modules that import from here.
+
+This module is a leaf: it must not import from any other pyclashbot.bot module.
+"""
+
+import numpy
+
+from pyclashbot.detection.image_rec import (
+    all_pixels_are_equal,
+    check_line_for_color,
+    find_image,
+    pixel_is_equal,
+)
+
+# ===== Battle ==========================================================
+
+
+def check_if_in_battle(emulator):
+    iar_bgr = emulator.screenshot()
+    if iar_bgr is None:
+        return False
+
+    # Convert to RGB for easier reasoning about expected colors.
+    iar = iar_bgr[..., ::-1]
+
+    def get_pixel(y: int, x: int) -> list[int] | None:
+        if y >= iar.shape[0] or x >= iar.shape[1]:
+            return None
+        return iar[y][x].tolist()
+
+    def is_bright(pixel: list[int] | None, threshold: int = 180) -> bool:
+        if pixel is None:
+            return False
+        return all(channel >= threshold for channel in pixel) or (
+            150 <= pixel[0] <= 195 and 40 <= pixel[1] <= 60 and 40 <= pixel[2] <= 60
+        )
+
+    def is_filled_crown(pixel: list[int] | None) -> bool:
+        """Check if pixel is a gold/yellow filled crown or UI accent."""
+        if pixel is None:
+            return False
+        r, g, b = pixel
+        return r >= 170 and g >= 130 and b <= 140
+
+    def is_scoreboard_purple(pixel: list[int] | None) -> bool:
+        if pixel is None:
+            return False
+        r, g, b = pixel
+        return r >= 200 and b >= 200 and g <= 140
+
+    def check_mode(coords: list[tuple[int, int]]) -> bool:
+        pixels = [get_pixel(y, x) for y, x in coords]
+        # Allow one of the "bright" UI pixels to change (crowns filling, overlays,
+        # small rendering differences) while still requiring the purple scoreboard.
+        bright_required = max(1, len(coords) - 2)
+        bright_count = sum(1 for pixel in pixels[:-1] if is_bright(pixel) or is_filled_crown(pixel))
+        return bright_count >= bright_required and is_scoreboard_purple(pixels[-1])
+
+    # When the emote is closed these pixels are not considered bright:
+    # (533, 80) RGB=[157, 44, 44] and (532, 77) RGB=[187, 55, 55]
+    coords_1v1 = [(528, 49), (532, 77), (546, 52), (546, 77), (618, 115)]
+    coords_2v2 = [(534, 53), (533, 80), (548, 52), (548, 76), (615, 114)]
+
+    if check_mode(coords_1v1):
+        return True
+    if check_mode(coords_2v2):
+        return True
+
+    return False
+
+
+def check_if_battle_has_ended(emulator) -> bool:
+    """Best-effort confirmation that a battle ended (avoid false positives mid-fight)."""
+    if check_if_on_clash_main_menu(emulator):
+        return True
+
+    if check_for_trophy_reward_menu(emulator):
+        return True
+
+    if check_for_post_battle_button(emulator):
+        return True
+
+    return False
+
+
+def check_for_post_battle_button(emulator) -> bool:
+    """Checks for the post-battle OK/Exit buttons (battle-end screen)."""
+    image = emulator.screenshot()
+    if image is None:
+        return False
+
+    if find_image(image, "ok_post_battle_button", tolerance=0.85) is not None:
+        return True
+
+    if find_image(image, "exit_battle_button", tolerance=0.9) is not None:
+        return True
+
+    return False
+
+
+def check_for_trophy_reward_menu(emulator) -> bool:
+    iar = emulator.screenshot()
+
+    pixels = [
+        iar[592][172],
+        iar[617][180],
+        iar[607][190],
+        iar[603][200],
+        iar[596][210],
+        iar[593][220],
+        iar[600][230],
+        iar[610][235],
+        iar[623][246],
+    ]
+    colors = [
+        [255, 184, 68],
+        [255, 175, 78],
+        [255, 175, 78],
+        [248, 239, 227],
+        [255, 187, 104],
+        [255, 176, 79],
+        [255, 187, 104],
+        [255, 175, 78],
+        [253, 135, 39],
+    ]
+
+    for i, pixel in enumerate(pixels):
+        if not pixel_is_equal(pixel, colors[i], tol=25):
+            return False
+
+    return True
+
+
+# ===== Fight in-progress / battle log ==================================
+
+ELIXIR_COORDS = [
+    [613, 149],
+    [613, 165],
+    [613, 188],
+    [613, 212],
+    [613, 240],
+    [613, 262],
+    [613, 287],
+    [613, 314],
+    [613, 339],
+    [613, 364],
+]
+ELIXIR_COLOR = [240, 137, 244]
+
+
+def count_elixer(emulator, elixer_count) -> bool:
+    """Method to check for 4 elixer during a battle"""
+    iar = emulator.screenshot()
+
+    if pixel_is_equal(
+        iar[ELIXIR_COORDS[elixer_count - 1][0], ELIXIR_COORDS[elixer_count - 1][1]],
+        ELIXIR_COLOR,
+        tol=65,
+    ):
+        return True
+    return False
+
+
+def check_pixels_for_win_in_battle_log(emulator) -> bool:
+    """Method to check pixels that appear in the battle
+    log to determing if the previous game was a win
+    """
+    line1 = check_line_for_color(
+        emulator,
+        x_1=47,
+        y_1=135,
+        x_2=109,
+        y_2=154,
+        color=(255, 51, 102),
+    )
+    line2 = check_line_for_color(
+        emulator,
+        x_1=46,
+        y_1=152,
+        x_2=115,
+        y_2=137,
+        color=(255, 51, 102),
+    )
+    line3 = check_line_for_color(
+        emulator,
+        x_1=47,
+        y_1=144,
+        x_2=110,
+        y_2=147,
+        color=(255, 51, 102),
+    )
+
+    if line1 and line2 and line3:
+        return False
+    return True
+
+
+# ===== Clash main menu =================================================
+
+
+def check_if_on_clash_main_menu(emulator) -> bool:
+    """Checks if the user is on the clash main menu.
+    Returns True if on main menu, False if not.
+    """
+    image = emulator.screenshot()
+    pixels = [
+        image[14][209],  # white
+        image[14][325],  # white
+        image[19][298],  # yellow
+        image[17][399],  # green
+        image[581][261],  # green
+        image[584][166],  # bluegrey
+        image[621][166],  # bluegrey
+    ]
+
+    # google play colors
+    colors_1 = [
+        [255, 255, 255],
+        [255, 255, 255],
+        [53, 199, 233],
+        [25, 198, 65],
+        [138, 105, 71],
+        [139, 105, 72],
+        [155, 120, 82],
+    ]
+
+    # memu colors
+    colors_2 = [
+        [255, 255, 255],
+        [255, 255, 255],
+        [53, 200, 233],
+        [24, 199, 65],
+        [138, 105, 71],
+        [139, 105, 72],
+        [155, 120, 81],
+    ]
+
+    # post Clash Royale app update colors
+    colors_3 = [
+        [57, 151, 206],
+        [21, 148, 42],
+        [36, 17, 1],
+        [231, 190, 123],
+        [140, 105, 74],
+        [140, 105, 74],
+        [156, 121, 82],
+    ]
+
+    for colors in [colors_1, colors_2, colors_3]:
+        if all_pixels_are_equal(
+            pixels,
+            colors,
+            25,
+        ):
+            return True
+
+    return False
+
+
+def check_if_on_clash_main_burger_button_options_menu(emulator) -> bool:
+    iar = emulator.screenshot()
+    pixels = [
+        iar[42][256],
+        iar[41][275],
+        iar[41][282],
+        iar[42][293],
+        iar[44][325],
+        iar[32][239],
+        iar[34][336],
+        iar[50][248],
+        iar[49][336],
+    ]
+    colors = [
+        [255, 255, 255],
+        [255, 255, 255],
+        [255, 255, 255],
+        [255, 255, 254],
+        [255, 255, 255],
+        [255, 187, 105],
+        [255, 187, 105],
+        [255, 175, 78],
+        [255, 175, 78],
+    ]
+    for i, color in enumerate(colors):
+        if not pixel_is_equal(pixels[i], color, tol=25):
+            return False
+    return True
+
+
+def check_if_battle_mode_is_selected(emulator, mode: str):
+    """Checks if the given battle mode is selected on the clash main menu.
+
+    Args:
+        emulator: The emulator controller.
+        mode: The battle mode to check for.
+
+    Returns:
+        True if the mode is selected, False otherwise.
+    """
+    expected_mode_types = ["Classic 1v1", "Classic 2v2", "Trophy Road"]
+
+    # Check if the mode is valid
+    if mode not in expected_mode_types:
+        print(f'[!] Fatal error: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.')
+        return None
+
+    mode2folder = {
+        "Classic 1v1": "selected_1v1_on_main",
+        "Classic 2v2": "selected_2v2_on_main",
+        "Trophy Road": "selected_trophy_road_on_main",
+    }
+
+    look_folder = mode2folder[mode]
+
+    print(f"[DEBUG] Checking if {mode} is selected...")
+    print(f"[DEBUG] Looking in folder: {look_folder}")
+    print("[DEBUG] Subcrop: (270, 455, 350, 533)")
+
+    # find image on screen
+    coord = find_image(
+        emulator.screenshot(),
+        look_folder,
+        tolerance=0.9,
+        subcrop=(270, 455, 350, 533),
+    )
+
+    print(f"[DEBUG] Found at: {coord}")
+
+    return coord is not None
+
+
+# ===== Sub-pages =======================================================
+
+
+def check_if_on_card_page(emulator) -> bool:
+    iar = emulator.screenshot()
+
+    pixels = [
+        iar[433][58],
+        iar[116][59],
+        iar[58][82],
+        iar[64][179],
+        iar[62][108],
+        iar[67][146],
+        iar[77][185],
+        iar[77][84],
+    ]
+
+    colors1 = [
+        [222, 0, 235],
+        [255, 255, 255],
+        [203, 137, 44],
+        [195, 126, 34],
+        [255, 255, 255],
+        [255, 255, 255],
+        [177, 103, 15],
+        [178, 104, 15],
+    ]
+
+    colors2 = [
+        [220, 0, 234],
+        [255, 255, 255],
+        [209, 68, 41],
+        [202, 64, 41],
+        [255, 255, 255],
+        [255, 255, 255],
+        [185, 52, 41],
+        [185, 52, 41],
+    ]
+
+    if all_pixels_are_equal(pixels, colors1, tol=25):
+        return True
+
+    if all_pixels_are_equal(pixels, colors2, tol=25):
+        return True
+
+    return False
+
+
+def check_if_on_battle_log_page(emulator) -> bool:
+    iar = emulator.screenshot()
+
+    pixels = [
+        iar[72][160],
+        iar[71][187],
+        iar[71][197],
+        iar[72][231],
+        iar[73][258],
+        iar[64][366],
+        iar[79][365],
+        iar[70][365],
+        iar[62][92],
+        iar[77][316],
+    ]
+    colors = [
+        [255, 255, 255],
+        [255, 255, 255],
+        [255, 255, 255],
+        [255, 255, 255],
+        [255, 255, 255],
+        [147, 135, 254],
+        [38, 38, 240],
+        [255, 255, 255],
+        [138, 122, 115],
+        [124, 106, 99],
+    ]
+
+    for i, p in enumerate(pixels):
+        if not pixel_is_equal(p, colors[i], tol=25):
+            return False
+    return True
+
+
+def check_if_on_shop(emulator) -> bool:
+    iar = emulator.screenshot()
+    pixels = [
+        iar[589][16],
+        iar[609][19],
+        iar[14][212],
+        iar[15][331],
+        iar[600][128],
+    ]
+    colors = [
+        [140, 107, 73],
+        [151, 116, 77],
+        [57, 160, 214],
+        [22, 186, 59],
+        [255, 225, 137],
+    ]
+    for i, p in enumerate(pixels):
+        if not pixel_is_equal(p, colors[i], tol=25):
+            return False
+    return True
+
+
+def check_if_on_social(emulator) -> bool:
+    iar = emulator.screenshot()
+    pixels = [
+        iar[601][218],
+        iar[577][342],
+        iar[620][299],
+    ]
+    colors = [
+        [255, 226, 138],
+        [142, 108, 75],
+        [155, 120, 82],
+    ]
+    for i, p in enumerate(pixels):
+        if not pixel_is_equal(p, colors[i], tol=25):
+            return False
+    return True
+
+
+def check_if_on_clan_chat(emulator) -> bool:
+    iar = emulator.screenshot()
+    pixels = [
+        iar[5][5],
+        iar[628][415],
+        iar[612][177],
+        iar[44][322],
+        iar[19][321],
+        iar[620][254],
+        iar[612][161],
+        iar[584][204],
+    ]
+    colors = [
+        [141, 85, 69],
+        [105, 85, 71],
+        [255, 175, 78],
+        [237, 215, 201],
+        [245, 231, 222],
+        [107, 86, 72],
+        [109, 87, 73],
+        [160, 128, 108],
+    ]
+    for i, p in enumerate(pixels):
+        if not pixel_is_equal(p, colors[i], tol=25):
+            return False
+    return True
+
+
+# ===== Popups ==========================================================
+
+CARD_MASTERY_COORD = (340, 440)
+CARD_MASTERY_BGR = (95, 214, 251)
+CARD_MASTERY_PIXEL_TOLERANCE = 15
+
+
+def card_mastery_rewards_exist(emulator):
+    screenshot = emulator.screenshot()
+
+    x, y = CARD_MASTERY_COORD
+    pixel = screenshot[y][x]
+
+    return pixel_is_equal(pixel, CARD_MASTERY_BGR, CARD_MASTERY_PIXEL_TOLERANCE)
+
+
+def check_for_inventory_full_popup(emulator):
+    iar = emulator.screenshot()
+    pixels = [
+        iar[410][220],
+        iar[420][225],
+        iar[416][225],
+        iar[418][230],
+        iar[420][240],
+        iar[430][250],
+        iar[435][260],
+        iar[427][270],
+        iar[429][280],
+        iar[435][290],
+    ]
+    colors = [
+        [255, 187, 105],
+        [255, 187, 105],
+        [255, 187, 105],
+        [244, 233, 220],
+        [60, 52, 43],
+        [255, 175, 78],
+        [255, 175, 78],
+        [255, 255, 255],
+        [241, 165, 74],
+        [255, 175, 78],
+    ]
+    for i, c in enumerate(colors):
+        if not pixel_is_equal(c, pixels[i], tol=15):
+            return False
+    return True
+
+
+# ===== Deck ============================================================
+
+
+def is_deck_full(emulator) -> bool:
+    iar = numpy.asarray(emulator.screenshot())
+    pixels = [
+        iar[172][43],
+        iar[172][130],
+        iar[172][216],
+        iar[172][302],
+        iar[310][43],
+        iar[311][130],
+        iar[309][216],
+        iar[309][302],
+    ]
+    valid_colors = [
+        [175, 5, 179],
+        [178, 5, 182],
+        [178, 5, 183],
+        [188, 2, 194],
+        [185, 4, 191],
+        [197, 2, 209],
+        [193, 2, 203],
+    ]
+    return all(any(pixel_is_equal(valid_color, p, tol=40) for valid_color in valid_colors) for p in pixels)
+
+
+def is_single_deck_layout_by_pixel(emulator) -> bool:
+    iar = numpy.asarray(emulator.screenshot())
+    pixel_coords = [(99, 165), (117, 166), (99, 313), (117, 313)]
+    expected_colors = [[141, 29, 0], [147, 34, 0], [145, 31, 4], [149, 34, 3]]
+    return all(
+        pixel_is_equal(expected, actual, tol=45)
+        for (x, y), expected in zip(pixel_coords, expected_colors)
+        for actual in [iar[y][x]]
+    )

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -12,7 +12,8 @@ from pyclashbot.bot.fight import (
     end_fight_state,
     start_fight,
 )
-from pyclashbot.bot.nav import check_if_battle_mode_is_selected, select_mode
+from pyclashbot.bot.nav import select_mode
+from pyclashbot.bot.state_detect import check_if_battle_mode_is_selected
 from pyclashbot.bot.upgrade_state import upgrade_cards_state
 from pyclashbot.interface.enums import UIField
 from pyclashbot.utils.caching import (

--- a/pyclashbot/bot/upgrade_state.py
+++ b/pyclashbot/bot/upgrade_state.py
@@ -1,11 +1,11 @@
 import time
 
 from pyclashbot.bot.nav import (
-    check_if_on_clash_main_menu,
     get_to_card_page_from_clash_main,
     select_mode,
     wait_for_clash_main_menu,
 )
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.detection.image_rec import pixel_is_equal
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger

--- a/pyclashbot/emulators/adb.py
+++ b/pyclashbot/emulators/adb.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 
 # Assuming these are in the correct path
-from pyclashbot.bot.nav import check_if_on_clash_main_menu
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.adb_base import AdbBasedController
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform, is_linux

--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -8,7 +8,7 @@ import time
 from contextlib import suppress
 from os.path import normpath
 
-from pyclashbot.bot.nav import check_if_on_clash_main_menu
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.adb_base import AdbBasedController
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform, is_macos

--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -7,7 +7,7 @@ from os.path import normpath
 
 import psutil
 
-from pyclashbot.bot.nav import check_if_on_clash_main_menu
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.adb_base import AdbBasedController
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform

--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -14,7 +14,7 @@ import numpy as np
 import psutil
 from pymemuc import PyMemuc, PyMemucError, VMInfo
 
-from pyclashbot.bot.nav import check_if_on_clash_main_menu
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.base import BaseEmulatorController
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform

--- a/tests/clash-royale/test_check_if_on_card_page.py
+++ b/tests/clash-royale/test_check_if_on_card_page.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 import sys
 
 from pyclashbot.bot.nav import (
-    check_if_on_card_page,
     get_to_card_page_from_clash_main,
     return_to_clash_main_from_card_page,
     wait_for_clash_main_menu,
 )
+from pyclashbot.bot.state_detect import check_if_on_card_page
 from pyclashbot.emulators.memu import MemuEmulatorController
 from pyclashbot.utils.logger import Logger
 

--- a/tests/clash-royale/test_check_if_on_clash_main_menu.py
+++ b/tests/clash-royale/test_check_if_on_clash_main_menu.py
@@ -16,11 +16,11 @@ from __future__ import annotations
 import sys
 
 from pyclashbot.bot.nav import (
-    check_if_on_clash_main_menu,
     get_to_card_page_from_clash_main,
     return_to_clash_main_from_card_page,
     wait_for_clash_main_menu,
 )
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.memu import MemuEmulatorController
 from pyclashbot.utils.logger import Logger
 

--- a/tests/clash-royale/test_get_to_card_page_from_clash_main.py
+++ b/tests/clash-royale/test_get_to_card_page_from_clash_main.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 import sys
 
 from pyclashbot.bot.nav import (
-    check_if_on_card_page,
     get_to_card_page_from_clash_main,
     return_to_clash_main_from_card_page,
     wait_for_clash_main_menu,
 )
+from pyclashbot.bot.state_detect import check_if_on_card_page
 from pyclashbot.emulators.memu import MemuEmulatorController
 from pyclashbot.utils.logger import Logger
 

--- a/tests/clash-royale/test_navigate_main_pages.py
+++ b/tests/clash-royale/test_navigate_main_pages.py
@@ -24,10 +24,10 @@ from pyclashbot.bot.nav import (
     MAIN_PAGE_CHECKS,
     NAV_CLICKS,
     PAGE_MAIN,
-    check_if_on_clash_main_menu,
     navigate_main_page,
     wait_for_clash_main_menu,
 )
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.memu import MemuEmulatorController
 from pyclashbot.utils.logger import Logger
 


### PR DESCRIPTION
## Summary
Consolidates 18 screenshot→bool state detectors into a new leaf module `pyclashbot/bot/state_detect.py`. Callers across `pyclashbot/` and `tests/` import directly from it. No behavior change.

## Moved
- From `nav.py`: check_if_in_battle, check_if_battle_has_ended, check_if_on_clash_main_menu, check_if_on_card_page, check_if_on_battle_log_page, check_if_on_clash_main_burger_button_options_menu, check_if_battle_mode_is_selected, check_if_on_shop, check_if_on_social, check_if_on_clan_chat, check_for_trophy_reward_menu, check_for_post_battle_button
- From `card_mastery_state.py`: card_mastery_rewards_exist, check_for_inventory_full_popup
- From `deck_utils.py`: is_deck_full, is_single_deck_layout_by_pixel
- From `fight.py`: count_elixer, check_pixels_for_win_in_battle_log

## Verification
- `uvx pre-commit run --all-files` passes
- All 60 project .py files import cleanly