### PR TITLE
refactor(nav): drop state_detect re-export shim

### DIFF
--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -5,7 +5,6 @@ from typing import Literal
 from pyclashbot.bot.constants import CLASH_MAIN_DEADSPACE_COORD as CLASH_MAIN_MENU_DEADSPACE_COORD
 from pyclashbot.bot.state_detect import (
     check_for_trophy_reward_menu,
-    check_if_battle_mode_is_selected,
     check_if_in_battle,
     check_if_on_battle_log_page,
     check_if_on_card_page,
@@ -21,20 +20,6 @@ from pyclashbot.detection.image_rec import (
 )
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
-
-# Re-export moved detectors so existing `from pyclashbot.bot.nav import check_if_*`
-# call sites keep working. New code should import from pyclashbot.bot.state_detect.
-__all__ = [
-    "check_if_battle_mode_is_selected",
-    "check_if_in_battle",
-    "check_if_on_battle_log_page",
-    "check_if_on_card_page",
-    "check_if_on_clan_chat",
-    "check_if_on_clash_main_burger_button_options_menu",
-    "check_if_on_clash_main_menu",
-    "check_if_on_shop",
-    "check_if_on_social",
-]
 
 CLASH_MAIN_OPTIONS_BURGER_BUTTON = (390, 62)
 BATTLE_LOG_BUTTON = (241, 43)


### PR DESCRIPTION
## Summary

Removes the `__all__` re-export block and the `check_if_battle_mode_is_selected` import from `pyclashbot/bot/nav.py`. After the state_detect refactor (PR #663), nav.py kept a backwards-compat shim that re-exported nine `check_if_*` functions so existing `from pyclashbot.bot.nav import check_if_*` call sites would keep working.

## Why this is a one-liner change rather than the bigger touch the plan doc anticipated

The Project 7 plan assumed the four `tests/clash-royale/test_*.py` files still imported state_detect helpers through `nav`. They don't — verified via `git grep`:

- `test_check_if_on_card_page.py` already imports `check_if_on_card_page` from `pyclashbot.bot.state_detect`.
- `test_check_if_on_clash_main_menu.py` already imports `check_if_on_clash_main_menu` from `pyclashbot.bot.state_detect`.
- `test_get_to_card_page_from_clash_main.py` already imports `check_if_on_card_page` from `pyclashbot.bot.state_detect`.
- `test_navigate_main_pages.py` already imports `check_if_on_clash_main_menu` from `pyclashbot.bot.state_detect`.

`git grep 'from pyclashbot\.bot\.nav import.*check_if'` returns no call sites — the shim has no remaining users. So the only cleanup needed was inside `nav.py` itself.

## What's left in nav.py's state_detect import

Eight functions remain imported from `state_detect` — but each is actually used inside `nav.py`'s own bodies (e.g., `check_if_on_clash_main_menu` in `wait_for_clash_main_menu`, `check_for_trophy_reward_menu` in popup-dismissal loops, `check_if_on_card_page` in nav flows). Only `check_if_battle_mode_is_selected` was import-for-re-export-only and is now removed.

## Out of scope

- Touching nav.py's actual nav functions or any test logic.
- Renaming or restructuring `state_detect.py`.

## Verification

- `uvx pre-commit run --all-files` → exits 0.
- `uv run python -c "from pyclashbot.bot import deck, nav, fight, state_detect, states, worker, upgrade_state, card_mastery_state"` → exits 0.
- `git grep -nE 'from pyclashbot\.bot\.nav import.*check_if'` → no matches.