### PR TITLE
refactor(state_detect): move pixel_indicates_upgradable from upgrade_state

### DIFF
--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -567,3 +567,11 @@ def is_single_deck_layout_by_pixel(emulator) -> bool:
         for (x, y), expected in zip(pixel_coords, expected_colors)
         for actual in [iar[y][x]]
     )
+
+
+# ===== Upgrade ========================================================
+
+
+def pixel_indicates_upgradable(bgr):
+    b, g, r = bgr
+    return g >= 240 and b <= 120 and r <= 40

--- a/pyclashbot/bot/upgrade_state.py
+++ b/pyclashbot/bot/upgrade_state.py
@@ -5,17 +5,10 @@ from pyclashbot.bot.nav import (
     select_mode,
     wait_for_clash_main_menu,
 )
-from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu, pixel_indicates_upgradable
 from pyclashbot.detection.image_rec import pixel_is_equal
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
-
-
-# Pixel criteria to detect upgrade emoji
-def pixel_indicates_upgradable(bgr):
-    b, g, r = bgr
-    return g >= 240 and b <= 120 and r <= 40
-
 
 # This indicates the green upgrade emoji. If we click it twice, the card upgrade menu will be opened.
 UPGRADE_POINTS = [


### PR DESCRIPTION
## Summary

Moves the pure pixel predicate `pixel_indicates_upgradable(bgr)` from `pyclashbot/bot/upgrade_state.py` into `pyclashbot/bot/state_detect.py` under a new `# ===== Upgrade =====` section.

## Rationale

This is a single oversight from before `state_detect.py` existed — the function is a pure 3-line pixel predicate that fits the same leaf-module pattern as the other 18 detectors already consolidated there. Centralizing it gives screen-detection logic a single home.

## What moved

```python
def pixel_indicates_upgradable(bgr):
    b, g, r = bgr
    return g >= 240 and b <= 120 and r <= 40
```

- Cut from `upgrade_state.py:15-17`.
- Pasted into `state_detect.py` at the end of the file under a new `# ===== Upgrade =====` section.
- `upgrade_state.py` now imports it: `from pyclashbot.bot.state_detect import check_if_on_clash_main_menu, pixel_indicates_upgradable`.

The function body, the thresholds (240/120/40), and the single caller (`detect_upgradable_cards` at `upgrade_state.py:detect_upgradable_cards`) are all unchanged.

## Out of scope

- No threshold tightening.
- No promotion of `240`/`120`/`40` magic numbers to named constants.
- `detect_upgradable_cards` stays in `upgrade_state.py` (workflow-y screenshot iteration; Project 2 may relocate it later).

## Verification

- `uvx pre-commit run --all-files` → exits 0.
- `uv run python -c "from pyclashbot.bot import upgrade_state, state_detect"` → exits 0.
- `git grep -nw pixel_indicates_upgradable` shows definition in `state_detect.py` + single use in `upgrade_state.py:detect_upgradable_cards`.