### PR TITLE
refactor(fight): drop do_2v2_fight_state wrapper

### DIFF
--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -109,24 +109,6 @@ def do_fight_state(
     return True
 
 
-def do_2v2_fight_state(
-    emulator,
-    logger: Logger,
-    random_fight_mode,
-    recording_flag: bool = False,
-) -> bool:
-    """Handle the entirety of the 2v2 battle state (start fight, do fight, end fight)."""
-    # Use the same fight logic as 1v1, just with 2v2 mode
-    return do_fight_state(
-        emulator,
-        logger,
-        random_fight_mode,
-        "Classic 2v2",
-        called_from_launching=False,
-        recording_flag=recording_flag,
-    )
-
-
 def start_fight(emulator, logger, mode) -> bool:
     """Start a fight with the specified mode.
 

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -6,7 +6,6 @@ import time
 from pyclashbot.bot.card_mastery_state import card_mastery_state
 from pyclashbot.bot.deck import randomize_deck_state, select_deck_state
 from pyclashbot.bot.fight import (
-    do_2v2_fight_state,
     do_fight_state,
     end_fight_state,
     start_fight,
@@ -425,15 +424,17 @@ def state_tree(
 
         recording_flag = job_list.get(UIField.RECORD_FIGHTS_TOGGLE, False)
         if (
-            do_2v2_fight_state(
+            do_fight_state(
                 emulator,
                 logger,
                 random_plays_flag,
-                recording_flag,
+                "Classic 2v2",
+                called_from_launching=False,
+                recording_flag=recording_flag,
             )
             is False
         ):
-            return handle_state_failure(logger, "2v2_fight", "do_2v2_fight_state", "2v2 fight failed")
+            return handle_state_failure(logger, "2v2_fight", "do_fight_state", "2v2 fight failed")
 
         return state_order.next_state(state)
 


### PR DESCRIPTION
## Summary

Deletes `do_2v2_fight_state` from `pyclashbot/bot/fight.py` (a 16-line pure-delegation wrapper around `do_fight_state(..., "Classic 2v2", called_from_launching=False)`) and rewrites the single call site in `pyclashbot/bot/states.py` to invoke `do_fight_state` directly with the mode argument.

## Changes

- **`pyclashbot/bot/fight.py`** — removed the `do_2v2_fight_state` function body.
- **`pyclashbot/bot/states.py`** — dropped `do_2v2_fight_state` from the `from pyclashbot.bot.fight import (...)` block; rewrote the 2v2 fight call site to call `do_fight_state` directly:

```python
if (
    do_fight_state(
        emulator,
        logger,
        random_plays_flag,
        "Classic 2v2",
        called_from_launching=False,
        recording_flag=recording_flag,
    )
    is False
):
    return handle_state_failure(logger, "2v2_fight", "do_fight_state", "2v2 fight failed")
```

The `handle_state_failure` third argument also changed from `"do_2v2_fight_state"` to `"do_fight_state"` — that's just the function-name label for the failure log message; no behavior change.

## Behavior preservation

`do_fight_state` already branches on `fight_mode_choosed == "Classic 2v2"` to call `logger.increment_classic_2v2_fights()`. The 2v2 logger counter still increments via that same code path.

## Out of scope

- Reworking `do_fight_state`'s signature.
- Splitting `_fight_loop` and `_random_fight_loop` (explicitly rejected previously — substantially different).

## Verification

- `uvx pre-commit run --all-files` → exits 0.
- `uv run python -c "from pyclashbot.bot import fight, states, worker"` → exits 0.
- `git grep -nw do_2v2_fight_state` → no matches.