### PR TITLE
feat: optional account switching (2–3 linked Supercell IDs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 __version__
 __pycache__
 recordings
+scripts/capture_output/
 .claude/
 .claude/settings.local.json
 .DS_Store

--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -69,6 +69,8 @@ def make_job_dictionary(values: dict[str, Any]) -> dict[str, Any]:
         UIField.DECK_NUMBER_SELECTION.value: as_int(UIField.DECK_NUMBER_SELECTION, 2),
         UIField.CYCLE_DECKS_USER_TOGGLE.value: as_bool(UIField.CYCLE_DECKS_USER_TOGGLE),
         UIField.MAX_DECK_SELECTION.value: as_int(UIField.MAX_DECK_SELECTION, 2),
+        UIField.SWITCH_ACCOUNTS_USER_TOGGLE.value: as_bool(UIField.SWITCH_ACCOUNTS_USER_TOGGLE),
+        UIField.MAX_ACCOUNT_SELECTION.value: as_int(UIField.MAX_ACCOUNT_SELECTION, 2),
         UIField.RANDOM_PLAYS_USER_TOGGLE.value: as_bool(UIField.RANDOM_PLAYS_USER_TOGGLE),
         UIField.DISABLE_WIN_TRACK_TOGGLE.value: as_bool(UIField.DISABLE_WIN_TRACK_TOGGLE),
         UIField.RECORD_FIGHTS_TOGGLE.value: as_bool(UIField.RECORD_FIGHTS_TOGGLE),

--- a/pyclashbot/bot/account_switch.py
+++ b/pyclashbot/bot/account_switch.py
@@ -1,0 +1,147 @@
+"""Switch between linked Supercell accounts from the main-menu burger menu."""
+
+import time
+
+from pyclashbot.bot.nav import (
+    CLASH_MAIN_OPTIONS_BURGER_BUTTON,
+    wait_for_clash_main_menu,
+)
+from pyclashbot.bot.state_detect import (
+    check_if_on_account_picker_by_pixels,
+    check_if_on_clash_main_burger_button_options_menu,
+    check_if_on_clash_main_menu,
+)
+from pyclashbot.utils.cancellation import interruptible_sleep
+from pyclashbot.utils.logger import Logger
+
+# 419x633 emulator resolution (same as CLASH_MAIN_OPTIONS_BURGER_BUTTON in nav.py).
+SWITCH_ACCOUNT_BUTTON_COORD = (221, 468)
+ACCOUNT_SLOT_CLICK_COORDS: dict[int, tuple[int, int]] = {
+    1: (253, 380),
+    2: (251, 476),
+    3: (252, 572),
+}
+
+ACCOUNT_SWITCH_MAIN_WAIT_TIMEOUT = 180
+ACCOUNT_PICKER_WAIT_TIMEOUT = 40
+SWITCH_ACCOUNT_LOAD_SLEEP = 3.0
+
+# Cold-start hardening (BlueStacks often needs an extra beat after main menu).
+MAIN_MENU_SETTLE_BEFORE_FIRST_SWITCH = 2.5
+BURGER_OPEN_ATTEMPTS = 2
+BURGER_MENU_WAIT_PER_ATTEMPT = 8
+SWITCH_ACCOUNT_ATTEMPTS = 2
+PICKER_MIN_WAIT_BEFORE_BURGER_GONE = 1.0
+
+_first_switch_this_process = True
+
+
+def _settle_main_menu_if_first_switch(logger: Logger) -> None:
+    global _first_switch_this_process
+    if not _first_switch_this_process:
+        return
+    logger.change_status("Waiting for main menu to settle...")
+    interruptible_sleep(MAIN_MENU_SETTLE_BEFORE_FIRST_SWITCH)
+    _first_switch_this_process = False
+
+
+def _open_burger_menu_with_retry(emulator, logger: Logger) -> bool:
+    for attempt in range(1, BURGER_OPEN_ATTEMPTS + 1):
+        if check_if_on_clash_main_burger_button_options_menu(emulator):
+            return True
+        if not check_if_on_clash_main_menu(emulator):
+            logger.change_status("Not on Clash main menu — cannot open burger menu")
+            return False
+        logger.change_status(f"Opening burger menu (try {attempt}/{BURGER_OPEN_ATTEMPTS})...")
+        emulator.click(*CLASH_MAIN_OPTIONS_BURGER_BUTTON)
+        deadline = time.time() + BURGER_MENU_WAIT_PER_ATTEMPT
+        while time.time() < deadline:
+            if check_if_on_clash_main_burger_button_options_menu(emulator):
+                return True
+            interruptible_sleep(0.5)
+    logger.change_status("Burger menu did not open")
+    return False
+
+
+def _click_switch_account_with_retry(emulator, logger: Logger) -> bool:
+    for attempt in range(1, SWITCH_ACCOUNT_ATTEMPTS + 1):
+        logger.change_status(f"Opening Switch Account (try {attempt}/{SWITCH_ACCOUNT_ATTEMPTS})...")
+        emulator.click(*SWITCH_ACCOUNT_BUTTON_COORD)
+        interruptible_sleep(SWITCH_ACCOUNT_LOAD_SLEEP)
+        if not check_if_on_clash_main_burger_button_options_menu(emulator):
+            return True
+        if attempt < SWITCH_ACCOUNT_ATTEMPTS:
+            logger.change_status("Still on burger menu — retrying Switch Account tap...")
+    logger.change_status("Still on burger menu after Switch Account taps")
+    return False
+
+
+def _wait_for_account_picker(emulator, logger: Logger) -> bool:
+    """Wait until the account list is up. Pixel colors vary by emulator; closing the burger menu counts."""
+    start = time.time()
+    logger.change_status("Waiting for Supercell ID account list...")
+    while time.time() - start < ACCOUNT_PICKER_WAIT_TIMEOUT:
+        if not check_if_on_clash_main_burger_button_options_menu(emulator):
+            if (time.time() - start) >= PICKER_MIN_WAIT_BEFORE_BURGER_GONE:
+                logger.change_status("Supercell ID account list open")
+                return True
+        elif check_if_on_account_picker_by_pixels(emulator):
+            logger.change_status("Supercell ID account list open (pixel match)")
+            return True
+
+        elapsed = int(time.time() - start)
+        logger.change_status(f"Waiting for account list ({elapsed}s)...")
+        interruptible_sleep(1)
+
+    if check_if_on_clash_main_burger_button_options_menu(emulator):
+        logger.change_status("Still on burger menu — Switch Account tap may be wrong")
+    else:
+        logger.change_status("Left burger menu but account list not confirmed")
+    return False
+
+
+def _click_account_slot(emulator, logger: Logger, slot: int) -> bool:
+    """Click account row `slot` (1 = first linked account, 2 = second, etc.)."""
+    if slot not in ACCOUNT_SLOT_CLICK_COORDS:
+        logger.change_status(f"No click coordinates for account slot {slot}")
+        return False
+    emulator.click(*ACCOUNT_SLOT_CLICK_COORDS[slot])
+    interruptible_sleep(2)
+    return True
+
+
+def switch_account_state(emulator, logger: Logger, account_slot: int) -> bool:
+    """Open the account picker and switch to `account_slot` (1-based). Returns True on main menu."""
+    if not check_if_on_clash_main_menu(emulator):
+        logger.change_status("Not on Clash main menu — cannot switch accounts")
+        return False
+
+    _settle_main_menu_if_first_switch(logger)
+
+    logger.change_status(f"Switching to account slot {account_slot}...")
+    if not _open_burger_menu_with_retry(emulator, logger):
+        return False
+
+    if not _click_switch_account_with_retry(emulator, logger):
+        return False
+
+    if not _wait_for_account_picker(emulator, logger):
+        return False
+
+    logger.change_status(f"Tapping account row {account_slot}...")
+    if not _click_account_slot(emulator, logger, account_slot):
+        return False
+
+    interruptible_sleep(2)
+    logger.change_status("Waiting for main menu after account switch...")
+    if not wait_for_clash_main_menu(
+        emulator,
+        logger,
+        deadspace_click=True,
+        timeout=ACCOUNT_SWITCH_MAIN_WAIT_TIMEOUT,
+    ):
+        logger.change_status("Timed out returning to main menu after account switch")
+        return False
+
+    logger.change_status(f"Now on account slot {account_slot}")
+    return True

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -106,14 +106,20 @@ def handle_trophy_reward_menu(
     return "good"
 
 
-def wait_for_clash_main_menu(emulator, logger: Logger, deadspace_click=True) -> bool:
+def wait_for_clash_main_menu(
+    emulator,
+    logger: Logger,
+    deadspace_click=True,
+    timeout: float | None = None,
+) -> bool:
     """Waits for the user to be on the clash main menu.
     Returns True if on main menu, prints the pixels if False then return False
     """
+    wait_timeout = CLASH_MAIN_WAIT_TIMEOUT if timeout is None else timeout
     start_time: float = time.time()
     while check_if_on_clash_main_menu(emulator) is not True:
         # timeout check
-        if time.time() - start_time > CLASH_MAIN_WAIT_TIMEOUT:
+        if time.time() - start_time > wait_timeout:
             logger.change_status("Timed out waiting for clash main")
             break
 
@@ -183,6 +189,26 @@ def return_to_clash_main_from_card_page(emulator, logger: Logger) -> bool:
     return True
 
 
+def open_clash_main_options_menu(emulator, logger: Logger, printmode: bool = False) -> bool:
+    """Open the burger menu from the Clash main screen. Returns False if not on main or menu never opens."""
+    if check_if_on_clash_main_menu(emulator) is not True:
+        logger.change_status(status="Not on clash main menu")
+        return False
+
+    if printmode:
+        logger.change_status(status="Opening clash main options menu")
+    else:
+        logger.log("Opening clash main options menu")
+    emulator.click(
+        CLASH_MAIN_OPTIONS_BURGER_BUTTON[0],
+        CLASH_MAIN_OPTIONS_BURGER_BUTTON[1],
+    )
+    if wait_for_clash_main_burger_button_options_menu(emulator, logger, printmode) == "restart":
+        logger.change_status(status="Timed out waiting for clash main options menu")
+        return False
+    return True
+
+
 def get_to_activity_log(
     emulator,
     logger: Logger,
@@ -193,26 +219,7 @@ def get_to_activity_log(
     else:
         logger.log("Getting to activity log")
 
-    # if not on main return restart
-    if check_if_on_clash_main_menu(emulator) is not True:
-        logger.change_status(
-            status="Eror 08752389 Not on clash main menu, restarting vm",
-        )
-        return "restart"
-
-    # click clash main burger options button
-    if printmode:
-        logger.change_status(status="Opening clash main options menu")
-    else:
-        logger.log("Opening clash main options menu")
-    emulator.click(
-        CLASH_MAIN_OPTIONS_BURGER_BUTTON[0],
-        CLASH_MAIN_OPTIONS_BURGER_BUTTON[1],
-    )
-    if wait_for_clash_main_burger_button_options_menu(emulator, logger) == "restart":
-        logger.change_status(
-            status="Error 99993 Waited too long for clash main options menu, restarting vm",
-        )
+    if not open_clash_main_options_menu(emulator, logger, printmode):
         return "restart"
 
     # click battle log button

--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -381,6 +381,40 @@ def check_if_on_card_page(emulator) -> bool:
     return False
 
 
+def check_if_on_account_picker_by_pixels(emulator) -> bool:
+    """Strict pixel match for the Supercell ID list. May fail on some emulators/renderers."""
+    iar = emulator.screenshot()
+    pixels = [
+        iar[110][209],
+        iar[125][209],
+        iar[55][380],
+        iar[200][100],
+    ]
+    colors = [
+        [255, 255, 255],
+        [31, 84, 158],
+        [9, 41, 104],
+        [60, 137, 195],
+    ]
+    for pixel, color in zip(pixels, colors, strict=True):
+        if not pixel_is_equal(pixel, color, tol=35):
+            return False
+    return True
+
+
+def check_if_on_account_picker(emulator) -> bool:
+    """True when the Supercell ID account list is open.
+
+    Uses pixels when they match; otherwise treats "burger menu closed" as the list
+    (main menu may still match under the overlay on some renderers, e.g. BlueStacks).
+    """
+    if check_if_on_clash_main_burger_button_options_menu(emulator):
+        return False
+    if check_if_on_account_picker_by_pixels(emulator):
+        return True
+    return not check_if_on_clash_main_burger_button_options_menu(emulator)
+
+
 def check_if_on_battle_log_page(emulator) -> bool:
     iar = emulator.screenshot()
 

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -3,6 +3,7 @@
 import random
 import time
 
+from pyclashbot.bot.account_switch import switch_account_state
 from pyclashbot.bot.card_mastery_state import card_mastery_state
 from pyclashbot.bot.deck import randomize_deck_state, select_deck_state
 from pyclashbot.bot.fight import (
@@ -194,6 +195,7 @@ class StateHistory:
 class StateOrder:
     def __init__(self):
         self.states = [
+            "switch_account",
             "upgrade",
             "card_mastery",
             "select_battle_mode",
@@ -256,6 +258,23 @@ def state_tree(
         emulator.restart()
         return state_order.next_state(state)
 
+    if state == "switch_account":
+        if not job_list.get(UIField.SWITCH_ACCOUNTS_USER_TOGGLE.value):
+            logger.log("Account switching isn't toggled. Skipping this state")
+            return state_order.next_state(state)
+
+        account_count = job_list.get(UIField.MAX_ACCOUNT_SELECTION.value, 2)
+        # get_next_account returns 0-based index; game list uses slots 1..N.
+        target_index = logger.get_next_account(account_count)
+        target_slot = target_index + 1
+
+        if switch_account_state(emulator, logger, target_slot):
+            logger.current_account = target_index
+            logger.add_account_to_account_history(target_index)
+            return state_order.next_state(state)
+
+        return handle_state_failure(logger, "switch_account", "switch_account_state")
+
     if state == "randomize_deck":
         # if randomize deck isn't toggled, return next state
         if not job_list[UIField.RANDOM_DECKS_USER_TOGGLE]:
@@ -288,7 +307,8 @@ def state_tree(
             logger.log("No battle mode selected, skipping deck cycling.")
             return state_order.next_state(state)
 
-        deck_cycle_index = get_deck_number_for_battle_mode(mode_used_in_1v1)
+        account_index = max(0, int(logger.current_account))
+        deck_cycle_index = get_deck_number_for_battle_mode(mode_used_in_1v1, account_index)
 
         deck_count = job_list.get(UIField.MAX_DECK_SELECTION.value, 10)
 
@@ -299,7 +319,7 @@ def state_tree(
 
         next_deck = selected_deck_number + 1 if selected_deck_number < deck_count else 1
 
-        set_deck_number_for_battle_mode(mode_used_in_1v1, next_deck)
+        set_deck_number_for_battle_mode(mode_used_in_1v1, next_deck, account_index)
 
         return state_order.next_state(state)
 

--- a/pyclashbot/interface/config.py
+++ b/pyclashbot/interface/config.py
@@ -101,6 +101,20 @@ JOBS = [
             )
         },
     ),
+    JobConfig(
+        UIField.SWITCH_ACCOUNTS_USER_TOGGLE,
+        "Switch accounts",
+        default=False,
+        extras={
+            UIField.MAX_ACCOUNT_SELECTION: ComboConfig(
+                key=UIField.MAX_ACCOUNT_SELECTION,
+                label="Accounts to cycle",
+                values=[2, 3],
+                default=2,
+                label_size=(15, 1),
+            )
+        },
+    ),
     JobConfig(UIField.RANDOM_PLAYS_USER_TOGGLE, "Random plays", default=False),
     JobConfig(UIField.DISABLE_WIN_TRACK_TOGGLE, "Skip win/loss check", default=False),
     JobConfig(UIField.CARD_MASTERY_USER_TOGGLE, "Card Masteries", default=False),
@@ -148,6 +162,8 @@ USER_CONFIG_KEYS = (
         UIField.DECK_NUMBER_SELECTION.value,
         UIField.MAX_DECK_SELECTION.value,
         UIField.CYCLE_DECKS_USER_TOGGLE.value,
+        UIField.MAX_ACCOUNT_SELECTION.value,
+        UIField.SWITCH_ACCOUNTS_USER_TOGGLE.value,
     ]
 )
 

--- a/pyclashbot/interface/enums.py
+++ b/pyclashbot/interface/enums.py
@@ -38,6 +38,8 @@ class UIField(StrEnum):
     DECK_NUMBER_SELECTION = "deck_number_selection"
     CYCLE_DECKS_USER_TOGGLE = "cycle_decks_user_toggle"
     MAX_DECK_SELECTION = "max_deck_selection"
+    SWITCH_ACCOUNTS_USER_TOGGLE = "switch_accounts_user_toggle"
+    MAX_ACCOUNT_SELECTION = "max_account_selection"
     RANDOM_PLAYS_USER_TOGGLE = "random_plays_user_toggle"
     DISABLE_WIN_TRACK_TOGGLE = "disable_win_track_toggle"
     RECORD_FIGHTS_TOGGLE = "record_fights_toggle"

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -85,6 +85,10 @@ class PyClashBotUI(ttk.Window):
         values[UIField.DECK_NUMBER_SELECTION.value] = self._safe_int(self.deck_var.get(), fallback=2)
         values[UIField.CYCLE_DECKS_USER_TOGGLE.value] = bool(self.jobs_vars[UIField.CYCLE_DECKS_USER_TOGGLE].get())
         values[UIField.MAX_DECK_SELECTION.value] = self._safe_int(self.max_deck_var.get(), fallback=2)
+        values[UIField.SWITCH_ACCOUNTS_USER_TOGGLE.value] = bool(
+            self.jobs_vars[UIField.SWITCH_ACCOUNTS_USER_TOGGLE].get()
+        )
+        values[UIField.MAX_ACCOUNT_SELECTION.value] = self._safe_int(self.max_account_var.get(), fallback=2)
         emulator_choice = self.emulator_var.get()
         values[UIField.MEMU_EMULATOR_TOGGLE.value] = emulator_choice == EmulatorType.MEMU
         values[UIField.GOOGLE_PLAY_EMULATOR_TOGGLE.value] = emulator_choice == EmulatorType.GOOGLE_PLAY
@@ -121,6 +125,8 @@ class PyClashBotUI(ttk.Window):
                 self.deck_var.set(str(values[UIField.DECK_NUMBER_SELECTION.value]))
             if UIField.MAX_DECK_SELECTION.value in values:
                 self.max_deck_var.set(str(values[UIField.MAX_DECK_SELECTION.value]))
+            if UIField.MAX_ACCOUNT_SELECTION.value in values:
+                self.max_account_var.set(str(values[UIField.MAX_ACCOUNT_SELECTION.value]))
             if UIField.THEME_NAME.value in values:
                 theme_value = str(values[UIField.THEME_NAME.value])
 
@@ -176,7 +182,8 @@ class PyClashBotUI(ttk.Window):
             self._suspend_traces -= 1
 
         if theme_value is not None:
-            self._apply_theme(theme_value)
+            # Defer until widgets exist; avoids macOS ttkbootstrap combobox popdown errors at startup.
+            self.after_idle(lambda t=theme_value: self._apply_theme(t))
 
         if UIField.DISCORD_RPC_TOGGLE.value in values:
             self.discord_rpc_var.set(bool(values[UIField.DISCORD_RPC_TOGGLE.value]))
@@ -460,10 +467,46 @@ class PyClashBotUI(ttk.Window):
         self._trace_variable(self.max_deck_var)
         self._register_config_widget(UIField.MAX_DECK_SELECTION.value, self.max_deck_spin)
 
-        add_job_checkbox(UIField.RANDOM_PLAYS_USER_TOGGLE, "❔ Random plays", 5, secondary_bootstyle)
-        add_job_checkbox(UIField.DISABLE_WIN_TRACK_TOGGLE, "⏭️ Skip win/loss check", 6, secondary_bootstyle)
-        add_job_checkbox(UIField.CARD_MASTERY_USER_TOGGLE, "🎯 Card Masteries", 7, secondary_bootstyle)
-        add_job_checkbox(UIField.CARD_UPGRADE_USER_TOGGLE, "⬆️ Upgrade Cards", 8, secondary_bootstyle)
+        account_job = jobs_by_key[UIField.SWITCH_ACCOUNTS_USER_TOGGLE]
+        account_config: ComboConfig = account_job.extras[UIField.MAX_ACCOUNT_SELECTION]
+        self.jobs_vars[UIField.SWITCH_ACCOUNTS_USER_TOGGLE] = ttk.BooleanVar(value=account_job.default)
+        account_checkbox = ttk.Checkbutton(
+            frame,
+            text="🔀 Switch accounts",
+            variable=self.jobs_vars[UIField.SWITCH_ACCOUNTS_USER_TOGGLE],
+            bootstyle=secondary_bootstyle,
+            command=self._notify_config_change,
+            width=checkbox_width,
+        )
+        account_checkbox.grid(row=5, column=0, sticky="w", pady=2)
+        self._trace_variable(self.jobs_vars[UIField.SWITCH_ACCOUNTS_USER_TOGGLE])
+        self._register_config_widget(UIField.SWITCH_ACCOUNTS_USER_TOGGLE.value, account_checkbox)
+
+        account_info = ttk.Label(frame, text="ⓘ", bootstyle="info")
+        account_info.grid(row=5, column=2, sticky="e", padx=(0, 2))
+        ToolTip(
+            account_info,
+            "How many linked Supercell accounts to swap between each bot loop (2-3). "
+            "Accounts are picked in the order you signed into them on this device.",
+        )
+        self.max_account_var = ttk.StringVar(value=str(account_config.default))
+        self.max_account_spin = ttk.Spinbox(
+            frame,
+            from_=min(account_config.values),
+            to=max(account_config.values),
+            width=6,
+            textvariable=self.max_account_var,
+            command=self._notify_config_change,
+            state=READONLY,
+        )
+        self.max_account_spin.grid(row=5, column=3, sticky="e")
+        self._trace_variable(self.max_account_var)
+        self._register_config_widget(UIField.MAX_ACCOUNT_SELECTION.value, self.max_account_spin)
+
+        add_job_checkbox(UIField.RANDOM_PLAYS_USER_TOGGLE, "❔ Random plays", 6, secondary_bootstyle)
+        add_job_checkbox(UIField.DISABLE_WIN_TRACK_TOGGLE, "⏭️ Skip win/loss check", 7, secondary_bootstyle)
+        add_job_checkbox(UIField.CARD_MASTERY_USER_TOGGLE, "🎯 Card Masteries", 8, secondary_bootstyle)
+        add_job_checkbox(UIField.CARD_UPGRADE_USER_TOGGLE, "⬆️ Upgrade Cards", 9, secondary_bootstyle)
 
     def _create_emulator_tab(self) -> None:
         # Main container frame for the tab
@@ -811,7 +854,11 @@ class PyClashBotUI(ttk.Window):
                 self.theme_var.set(selected)
             finally:
                 self._suspend_traces -= 1
-        self._style.theme_use(selected)
+        try:
+            self._style.theme_use(selected)
+        except tk.TclError:
+            # Stale combobox popdown during theme refresh; safe to ignore until next interaction.
+            return
         self._refresh_theme_colours()
 
     def _label_foreground(self) -> str:

--- a/pyclashbot/utils/caching.py
+++ b/pyclashbot/utils/caching.py
@@ -75,16 +75,21 @@ def _get_deck_cache():
     return _thread_local.deck_cache
 
 
-def get_deck_number_for_battle_mode(battle_mode: str) -> int:
-    """Get the deck number for a specific battle mode from the thread-local cache."""
-    cache = _get_deck_cache()
-    return cache.get(battle_mode, 1)
+def _deck_cache_key(account_index: int, battle_mode: str) -> str:
+    """Deck cycle index is tracked per account and per battle mode."""
+    return f"{account_index}:{battle_mode}"
 
 
-def set_deck_number_for_battle_mode(battle_mode: str, deck_number: int):
-    """Set the deck number for a specific battle mode in the thread-local cache."""
+def get_deck_number_for_battle_mode(battle_mode: str, account_index: int = 0) -> int:
+    """Get the deck number for a battle mode on the given account (thread-local cache)."""
     cache = _get_deck_cache()
-    cache[battle_mode] = deck_number
+    return cache.get(_deck_cache_key(account_index, battle_mode), 1)
+
+
+def set_deck_number_for_battle_mode(battle_mode: str, deck_number: int, account_index: int = 0):
+    """Set the deck number for a battle mode on the given account (thread-local cache)."""
+    cache = _get_deck_cache()
+    cache[_deck_cache_key(account_index, battle_mode)] = deck_number
 
 
 ### The following section is for supporting the old pickle format for user settings ###


### PR DESCRIPTION
## Summary

- Adds a **Switch accounts** Jobs toggle (2 or 3 linked accounts) that runs at the start of each bot loop.
- Implements burger menu → Switch Account → slot click using fixed click coordinates at the standard **419×633** emulator resolution (same as the rest of the bot).
- BlueStacks-friendly picker detection, cold-start retries (main-menu settle, burger/Switch Account re-tap), and per-account deck cycle indices when deck cycling is enabled.

## Test plan

- [ ] BlueStacks 5 (or MEmu) at 419×633, Clash on main menu, 2 linked accounts on device
- [ ] Enable **Switch accounts** (2), Classic 2v2; fresh emulator restart
- [ ] First loop: settle wait, burger + Switch Account on try 1, account list opens, returns to main
- [ ] Second loop: switches to account slot 2 and continues normal state order
- [ ] Disable toggle: `switch_account` state skipped
- [ ] macOS: `make dev` starts without ttk theme `TclError`