### PR TITLE
refactor(find): consolidate pure detectors into find.py

### DIFF
--- a/pyclashbot/bot/find.py
+++ b/pyclashbot/bot/find.py
@@ -1,0 +1,97 @@
+"""Pure screen-detection helpers.
+
+Imports only from pyclashbot.detection.*, pyclashbot.utils.*, and pyclashbot.bot.coords.
+Never imports from other pyclashbot.bot.* modules, with one exception:
+detect_upgradable_cards reuses pixel_indicates_upgradable from state_detect (a leaf
+predicate module that does not import from find).
+"""
+
+from pyclashbot.bot.coords import UPGRADE_POINTS
+from pyclashbot.bot.state_detect import pixel_indicates_upgradable
+from pyclashbot.detection.image_rec import find_image, pixel_is_equal
+
+
+def find_fight_mode_icon(emulator, mode: str):
+    expected_mode_types = ["Classic 1v1", "Classic 2v2", "Trophy Road"]
+
+    # Check if the mode is valid
+    if mode not in expected_mode_types:
+        print(f'[!] Fatal error: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.')
+        return None
+
+    mode2folder = {
+        "Classic 1v1": "fight_mode_1v1",
+        "Classic 2v2": "fight_mode_2v2",
+        "Trophy Road": "fight_mode_trophy_road",
+    }
+
+    look_folder = mode2folder[mode]
+
+    image = emulator.screenshot()
+
+    fight_mode_1v1_button_location = find_image(
+        image,
+        look_folder,
+        tolerance=0.9,
+        show_image=False,
+    )
+    if fight_mode_1v1_button_location is not None:
+        return fight_mode_1v1_button_location
+    return None
+
+
+def find_post_battle_button(emulator):
+    """Find and return coordinates for post-battle exit/OK button.
+
+    Tries multiple detection methods in order:
+    1. Pixel-based detection (fastest)
+    2. Image recognition for OK button
+    3. Image recognition for exit button
+
+    Returns:
+        tuple[int, int] | None: Button coordinates (x, y) or None if not found
+    """
+    iar = emulator.screenshot()
+
+    pixels = [
+        iar[545][178],
+        iar[547][239],
+        iar[553][214],
+        iar[554][201],
+    ]
+    colors = [
+        [255, 187, 104],
+        [255, 187, 104],
+        [255, 255, 255],
+        [255, 255, 255],
+    ]
+
+    pixel_match = True
+    for i, p in enumerate(pixels):
+        if not pixel_is_equal(p, colors[i], tol=20):
+            pixel_match = False
+            break
+
+    if pixel_match:
+        return (200, 550)
+
+    coord = find_image(iar, "ok_post_battle_button", tolerance=0.85)
+    if coord is not None:
+        return coord
+
+    coord = find_image(iar, "exit_battle_button", tolerance=0.9)
+    if coord is not None:
+        return coord
+
+    return None
+
+
+def detect_upgradable_cards(emulator):
+    img = emulator.screenshot()
+    upgradable = []
+
+    for i, (x, y) in enumerate(UPGRADE_POINTS, start=1):
+        if pixel_indicates_upgradable(img[y][x]):
+            upgradable.append(i)
+
+    return upgradable

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -14,6 +14,7 @@ from pyclashbot.bot.coords import (
     OK_BUTTON_COORDS_IN_TROPHY_REWARD_PAGE,
 )
 from pyclashbot.bot.coords import CLASH_MAIN_DEADSPACE_COORD as CLASH_MAIN_MENU_DEADSPACE_COORD
+from pyclashbot.bot.find import find_fight_mode_icon, find_post_battle_button
 from pyclashbot.bot.state_detect import (
     check_for_trophy_reward_menu,
     check_if_in_battle,
@@ -25,10 +26,7 @@ from pyclashbot.bot.state_detect import (
     check_if_on_shop,
     check_if_on_social,
 )
-from pyclashbot.detection.image_rec import (
-    find_image,
-    pixel_is_equal,
-)
+from pyclashbot.detection.image_rec import find_image
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
 
@@ -302,35 +300,6 @@ def wait_for_clash_main_burger_button_options_menu(
     return "good"
 
 
-def find_fight_mode_icon(emulator, mode: str):
-    expected_mode_types = ["Classic 1v1", "Classic 2v2", "Trophy Road"]
-
-    # Check if the mode is valid
-    if mode not in expected_mode_types:
-        print(f'[!] Fatal error: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.')
-        return None
-
-    mode2folder = {
-        "Classic 1v1": "fight_mode_1v1",
-        "Classic 2v2": "fight_mode_2v2",
-        "Trophy Road": "fight_mode_trophy_road",
-    }
-
-    look_folder = mode2folder[mode]
-
-    image = emulator.screenshot()
-
-    fight_mode_1v1_button_location = find_image(
-        image,
-        look_folder,
-        tolerance=0.9,
-        show_image=False,
-    )
-    if fight_mode_1v1_button_location is not None:
-        return fight_mode_1v1_button_location
-    return None
-
-
 def select_mode(emulator, mode: str):
     # Check if the mode is valid
     expected_mode_types = ["Classic 1v1", "Classic 2v2", "Trophy Road"]
@@ -484,52 +453,6 @@ def switch_deck_page(emulator, logger: Logger) -> bool:
 
 
 # ===== Post-battle navigation =========================================
-
-
-def find_post_battle_button(emulator):
-    """Find and return coordinates for post-battle exit/OK button.
-
-    Tries multiple detection methods in order:
-    1. Pixel-based detection (fastest)
-    2. Image recognition for OK button
-    3. Image recognition for exit button
-
-    Returns:
-        tuple[int, int] | None: Button coordinates (x, y) or None if not found
-    """
-    iar = emulator.screenshot()
-
-    pixels = [
-        iar[545][178],
-        iar[547][239],
-        iar[553][214],
-        iar[554][201],
-    ]
-    colors = [
-        [255, 187, 104],
-        [255, 187, 104],
-        [255, 255, 255],
-        [255, 255, 255],
-    ]
-
-    pixel_match = True
-    for i, p in enumerate(pixels):
-        if not pixel_is_equal(p, colors[i], tol=20):
-            pixel_match = False
-            break
-
-    if pixel_match:
-        return (200, 550)
-
-    coord = find_image(iar, "ok_post_battle_button", tolerance=0.85)
-    if coord is not None:
-        return coord
-
-    coord = find_image(iar, "exit_battle_button", tolerance=0.9)
-    if coord is not None:
-        return coord
-
-    return None
 
 
 def get_to_main_after_fight(emulator, logger):

--- a/pyclashbot/bot/upgrade_state.py
+++ b/pyclashbot/bot/upgrade_state.py
@@ -14,26 +14,16 @@ from pyclashbot.bot.coords import (
     UPGRADE_RETURN_TO_MAIN_COORD_1,
     UPGRADE_RETURN_TO_MAIN_COORD_2,
 )
+from pyclashbot.bot.find import detect_upgradable_cards
 from pyclashbot.bot.nav import (
     get_to_card_page_from_clash_main,
     select_mode,
     wait_for_clash_main_menu,
 )
-from pyclashbot.bot.state_detect import check_if_on_clash_main_menu, pixel_indicates_upgradable
+from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.detection.image_rec import pixel_is_equal
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
-
-
-def detect_upgradable_cards(emulator):
-    img = emulator.screenshot()
-    upgradable = []  # it will be garbage collected right?
-
-    for i, (x, y) in enumerate(UPGRADE_POINTS, start=1):
-        if pixel_indicates_upgradable(img[y][x]):
-            upgradable.append(i)
-
-    return upgradable
 
 
 def upgrade_card(emulator, upgradable, logger: Logger):


### PR DESCRIPTION
## What

Creates `pyclashbot/bot/find.py` as a leaf-style module holding pure screen-detection helpers. Three functions move in:

- `find_fight_mode_icon` (from `nav.py`)
- `find_post_battle_button` (from `nav.py`)
- `detect_upgradable_cards` (from `upgrade_state.py`)

Old call sites in `nav.py` and `upgrade_state.py` are updated to import from `pyclashbot.bot.find`. No behavior changes — same bodies, same signatures, same pixel/image tolerances.

## Leaf-module rule

`find.py` imports only from:
- `pyclashbot.detection.*`
- `pyclashbot.utils.*`
- `pyclashbot.bot.coords` (allowed — coords is itself leaf-style)
- `pyclashbot.bot.state_detect` (one documented exception, for `pixel_indicates_upgradable`)

The `state_detect` import is an exception to the strict leaf rule. `state_detect` is itself a leaf predicate module that does not import from `find.py`, so there is no circular-dependency risk. The alternatives (inlining the 3-line predicate, or duplicating it) would either change observable code locality or violate DRY for no benefit. Documented at the top of `find.py`.

## Naming

Kept `detect_upgradable_cards` as-is rather than renaming to `find_upgradable_cards`. The naming bikeshed was called out in the plan as not worth the churn.

## Out of scope

- `find_and_click_deck` / `find_and_select_deck_for_randomization` — these are workflow functions (multiple click sites, deck-specific iteration logic), not pure detectors. They stay in `deck.py` per the rubric.
- `find_closest_card` in `card_detection.py` — operates on in-memory data, not screen.
- Any signature changes, behavior changes, or threshold tightening.

## Verification

- `uvx pre-commit run --all-files` exits 0.
- `uv run python -c "from pyclashbot.bot import find, nav, deck, fight, state_detect, states, upgrade_state, card_mastery_state, worker, coords"` succeeds.
- `git grep -nE '^from pyclashbot\.bot\.' pyclashbot/bot/find.py` returns only `coords` and `state_detect` (the documented exception).