### PR TITLE
fix: spelling and copy typos in fight logs, UI, and identifiers

### DIFF
--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -37,7 +37,7 @@ from pyclashbot.interface.ui import PyClashBotUI, no_jobs_popup
 from pyclashbot.utils.caching import USER_SETTINGS_CACHE
 from pyclashbot.utils.cli_config import arg_parser
 from pyclashbot.utils.discord_rpc import DiscordRPCManager
-from pyclashbot.utils.logger import Logger, initalize_pylogging, log_dir
+from pyclashbot.utils.logger import Logger, initialize_pylogging, log_dir
 from pyclashbot.utils.open_folder import open_folder
 from pyclashbot.utils.platform import is_macos
 
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-initalize_pylogging()
+initialize_pylogging()
 
 
 def migrate_clan_job_settings(values: dict[str, Any]) -> None:

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -33,12 +33,12 @@ from pyclashbot.bot.state_detect import (
     check_if_in_battle,
     check_if_on_clash_main_menu,
     check_pixels_for_win_in_battle_log,
-    count_elixer,
+    count_elixir,
 )
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
 
-ELIXER_WAIT_TIMEOUT = 40  # way to high but someone got errors with that so idk
+ELIXIR_WAIT_TIMEOUT = 40  # way to high but someone got errors with that so idk
 
 
 def do_fight_state(
@@ -165,23 +165,23 @@ def mag_dump(emulator, logger):
         interruptible_sleep(0.1)
 
 
-def wait_for_elixer(
+def wait_for_elixir(
     emulator,
     logger,
-    random_elixer_wait,
+    elixir_wait_amount,
     WAIT_THRESHOLD=5000,  # noqa: N803
     PLAY_THRESHOLD=10000,  # noqa: N803
     recording_flag: bool = False,
 ) -> Literal["restart", "no battle"] | bool:
-    """Method to wait for 4 elixer during a battle"""
+    """Method to wait for 4 elixir during a battle"""
     start_time = time.time()
     battle_detection_lost_count = 0
 
-    while not count_elixer(emulator, random_elixer_wait):
+    while not count_elixir(emulator, elixir_wait_amount):
         # debug screenshot saving removed from production
         wait_time = time.time() - start_time
         logger.change_status(
-            f"Waiting for {random_elixer_wait} elixer for {str(wait_time)[:4]}s...",
+            f"Waiting for {elixir_wait_amount} elixir for {str(wait_time)[:4]}s...",
         )
 
         card_inhand = len(check_which_cards_are_available(emulator, True, False))
@@ -194,22 +194,22 @@ def wait_for_elixer(
             logger.change_status("All cards are available!")
             return True
 
-        if wait_time > ELIXER_WAIT_TIMEOUT:
-            logger.change_status(status="Waited too long for elixer")
+        if wait_time > ELIXIR_WAIT_TIMEOUT:
+            logger.change_status(status="Waited too long for elixir")
             return "restart"
 
         if not check_for_in_battle_with_delay(emulator):
             if check_if_battle_has_ended(emulator):
-                logger.change_status(status="Not in battle anymore (confirmed), stopping waiting for elixer.")
+                logger.change_status(status="Not in battle anymore (confirmed), stopping waiting for elixir.")
                 return "no battle"
 
             battle_detection_lost_count += 1
             logger.change_status(
-                status="Lost battle detection while waiting for elixer; assuming still in battle.",
+                status="Lost battle detection while waiting for elixir; assuming still in battle.",
             )
             if battle_detection_lost_count >= 4:
                 logger.change_status(
-                    status="Lost battle detection repeatedly while waiting for elixer; assuming battle ended.",
+                    status="Lost battle detection repeatedly while waiting for elixir; assuming battle ended.",
                 )
                 return "no battle"
 
@@ -219,7 +219,7 @@ def wait_for_elixer(
         battle_detection_lost_count = 0
 
     logger.change_status(
-        f"Took {str(time.time() - start_time)[:4]}s for {random_elixer_wait} elixer.",
+        f"Took {str(time.time() - start_time)[:4]}s for {elixir_wait_amount} elixir.",
     )
 
     return True
@@ -524,7 +524,7 @@ def _fight_loop(emulator, logger: Logger, recording_flag: bool) -> bool:
         elixir_amount = battle_strategy.select_elixir_amount()
         wait_threshold, play_threshold = battle_strategy.get_thresholds()
 
-        wait_output = wait_for_elixer(
+        wait_output = wait_for_elixir(
             emulator,
             logger,
             elixir_amount,
@@ -534,7 +534,7 @@ def _fight_loop(emulator, logger: Logger, recording_flag: bool) -> bool:
         )
 
         if wait_output == "restart":
-            logger.change_status("Failure while waiting for elixer")
+            logger.change_status("Failure while waiting for elixir")
             return False
 
         if wait_output == "no battle":

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -38,14 +38,14 @@ from pyclashbot.bot.state_detect import (
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
 
-ELIXIR_WAIT_TIMEOUT = 40  # way to high but someone got errors with that so idk
+ELIXIR_WAIT_TIMEOUT = 40  # too high but someone got errors with that so idk
 
 
 def do_fight_state(
     emulator,
     logger: Logger,
     random_fight_mode,
-    fight_mode_choosed,
+    fight_mode_chosen,
     called_from_launching=False,
     recording_flag: bool = False,
 ) -> bool:
@@ -62,7 +62,7 @@ def do_fight_state(
         return False
 
     logger.change_status("Starting fight loop")
-    logger.log(f'This is the fight mode: "{fight_mode_choosed}"')
+    logger.log(f'This is the fight mode: "{fight_mode_chosen}"')
 
     # Run regular fight loop if random mode not toggled
     if not random_fight_mode and _fight_loop(emulator, logger, recording_flag) is False:
@@ -76,16 +76,16 @@ def do_fight_state(
 
     # Only log the fight if not called from the start
     if not called_from_launching:
-        if fight_mode_choosed in ["Classic 1v1", "Trophy Road"]:
+        if fight_mode_chosen in ["Classic 1v1", "Trophy Road"]:
             logger.add_1v1_fight()
-        elif fight_mode_choosed == "Classic 2v2":
+        elif fight_mode_chosen == "Classic 2v2":
             logger.increment_2v2_fights()
 
-        if fight_mode_choosed == "Trophy Road":
+        if fight_mode_chosen == "Trophy Road":
             logger.increment_trophy_road_fights()
-        elif fight_mode_choosed == "Classic 1v1":
+        elif fight_mode_chosen == "Classic 1v1":
             logger.increment_classic_1v1_fights()
-        elif fight_mode_choosed == "Classic 2v2":
+        elif fight_mode_chosen == "Classic 2v2":
             logger.increment_classic_2v2_fights()
 
     interruptible_sleep(10)
@@ -126,9 +126,9 @@ def start_fight(emulator, logger, mode) -> bool:
     emulator.click(START_FIGHT_BUTTON_COORD[0], START_FIGHT_BUTTON_COORD[1])
     logger.log(f"Clicked Start button at {START_FIGHT_BUTTON_COORD}")
 
-    # if its 2v2 mode, we gotta click that second popup
+    # 2v2 needs a second popup after Start
     if mode == "Classic 2v2":
-        logger.change_status("Its 2v2 mode so we gotta click the quickmatch popup option!")
+        logger.change_status("2v2 mode — clicking the quickmatch popup...")
         interruptible_sleep(3)
         emulator.click(QUICKMATCH_POPUP_BUTTON_COORD[0], QUICKMATCH_POPUP_BUTTON_COORD[1])
         logger.log(f"Clicked Quickmatch button at {QUICKMATCH_POPUP_BUTTON_COORD}")
@@ -338,9 +338,9 @@ def play_a_card(emulator, logger, recording_flag: bool, battle_strategy: "Battle
     # check which cards are available
     logger.change_status("Looking at which cards are available")
     available_card_check_start_time = time.time()
-    card_indicies = check_which_cards_are_available(emulator, False, True)
+    card_indices = check_which_cards_are_available(emulator, False, True)
 
-    if not card_indicies:
+    if not card_indices:
         logger.change_status("No cards ready yet...")
         return False
 
@@ -349,10 +349,10 @@ def play_a_card(emulator, logger, recording_flag: bool, battle_strategy: "Battle
     )[:3]
 
     logger.change_status(
-        f"These cards are available: {card_indicies} ({available_card_check_time_taken}s)",
+        f"These cards are available: {card_indices} ({available_card_check_time_taken}s)",
     )
 
-    card_index = select_card_index(card_indicies, last_three_cards)
+    card_index = select_card_index(card_indices, last_three_cards)
     if card_index not in last_three_cards:
         last_three_cards.append(card_index)
     logger.change_status(f"Choosing this card index: {card_index}")

--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -169,7 +169,7 @@ def count_elixir(emulator, elixir_count) -> bool:
 
 def check_pixels_for_win_in_battle_log(emulator) -> bool:
     """Method to check pixels that appear in the battle
-    log to determing if the previous game was a win
+    log to determine if the previous game was a win
     """
     line1 = check_line_for_color(
         emulator,

--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -154,12 +154,12 @@ ELIXIR_COORDS = [
 ELIXIR_COLOR = [240, 137, 244]
 
 
-def count_elixer(emulator, elixer_count) -> bool:
-    """Method to check for 4 elixer during a battle"""
+def count_elixir(emulator, elixir_count) -> bool:
+    """Method to check for 4 elixir during a battle"""
     iar = emulator.screenshot()
 
     if pixel_is_equal(
-        iar[ELIXIR_COORDS[elixer_count - 1][0], ELIXIR_COORDS[elixer_count - 1][1]],
+        iar[ELIXIR_COORDS[elixir_count - 1][0], ELIXIR_COORDS[elixir_count - 1][1]],
         ELIXIR_COLOR,
         tol=65,
     ):

--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -159,7 +159,7 @@ class GooglePlayEmulatorController(AdbBasedController):
 
     def __del__(self):
         print("Cleaning up google emulator controller object...")
-        print("Cant call self here so idk what to do.")
+        print("Can't call self here; cleanup is handled elsewhere.")
         print("Someone 10x try to clear google play processes here")
 
     def _connect(self):

--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -156,7 +156,7 @@ class MemuEmulatorController(BaseEmulatorController):
         self.screenshotter = MemuScreenCapture(self.pmc)
 
         # get a valid vm to use
-        self._initalize_valid_vm()
+        self._initialize_valid_vm()
 
         self.logger.log(f"Initializing MemuEmulatorController took {str(time.time() - init_start_time)[:5]} seconds")
         if self.debug_mode:
@@ -165,9 +165,9 @@ class MemuEmulatorController(BaseEmulatorController):
     def __del__(self):
         self.logger.log("Need to clear residual memu processes here")
 
-    def _initalize_valid_vm(self):
+    def _initialize_valid_vm(self):
         # no timeout here bc if this fails, then something fatal is wrong
-        self.logger.log("Initalizing memu vm...")
+        self.logger.log("Initializing MEmu VM...")
         vm_index = -1
         while 1:
             # check for a valid vm

--- a/pyclashbot/interface/setup.py
+++ b/pyclashbot/interface/setup.py
@@ -8,8 +8,8 @@ def show_clash_royale_setup_gui() -> None:
     root = tk.Tk()
     root.withdraw()
     messagebox.showerror(
-        "Clash Royale Not Setup!",
-        "Clash Royale is not installed or setup.\n"
+        "Clash Royale Not Set Up!",
+        "Clash Royale is not installed or set up.\n"
         "Please install Clash Royale, finish the in-game tutorial,\n"
         "and log in before using this bot.",
     )

--- a/pyclashbot/utils/logger.py
+++ b/pyclashbot/utils/logger.py
@@ -39,8 +39,8 @@ def compress_logs() -> None:
                 remove(log)
 
 
-def initalize_pylogging() -> None:
-    """Method to be called once to initalize python logging"""
+def initialize_pylogging() -> None:
+    """Method to be called once to initialize python logging"""
     if not exists(log_dir):
         makedirs(log_dir)
 
@@ -244,7 +244,7 @@ class Logger:
 
     def calc_time_since_start(self) -> str:
         """Calculate time since start of bot using logger's
-        stats and reutrn as string in hours:mins:seconds
+        stats and return as string in hours:mins:seconds
         """
         if self.start_time is not None:
             hours, remainder = divmod(time.time() - self.start_time, 3600)


### PR DESCRIPTION
## Summary

- Fixes leftover `elixer` → `elixir` in battle wait status messages (GUI + terminal).
- Corrects user-visible copy: 2v2 quickmatch status, Clash Royale setup dialog, MEmu VM init log.
- Fixes docstring typos (`determining`, `return`, `too high` comment).
- Renames misspelled identifiers: `fight_mode_chosen`, `card_indices`, `initialize_pylogging`, `_initialize_valid_vm`.

## Context

#673 fixed some Elixir/upgrade/MEmu strings; fight-loop wait logs and several other typos were still present.

## Test plan

- [ ] Run bot through a battle; confirm status lines use `elixir` and updated 2v2 quickmatch message.
- [ ] Trigger setup dialog (if applicable): "Not Set Up" / "set up" wording.
- [ ] MEmu start: log shows "Initializing MEmu VM...".
- [ ] `make lint` (pre-commit passed on commit).