### PR TITLE
chore: route Discord links through pyclashbot.app/discord/invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An open-source automation tool for Clash Royale on Windows and macOS. Uses Android emulation and image recognition to automate card leveling, pass progression, and daily gameplay tasks.
 
-[Join our Discord](https://discord.gg/nqKRkyq2UU) for support and updates.
+[Join our Discord](https://pyclashbot.app/discord/invite) for support and updates.
 
 ## Features
 
@@ -86,7 +86,7 @@ Default settings work for most users. Only enable "Show advanced settings" to ch
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) | [Discord](https://discord.gg/nqKRkyq2UU) | [Issues](https://github.com/pyclashbot/py-clash-bot/issues)
+See [CONTRIBUTING.md](CONTRIBUTING.md) | [Discord](https://pyclashbot.app/discord/invite) | [Issues](https://github.com/pyclashbot/py-clash-bot/issues)
 
 ## License
 

--- a/pyclashbot/utils/discord_rpc.py
+++ b/pyclashbot/utils/discord_rpc.py
@@ -13,7 +13,7 @@ class DiscordRPCManager:
     APP_ID = "1181655703446888469"
     BUTTONS = [
         {"label": "GitHub", "url": "https://github.com/pyclashbot/py-clash-bot"},
-        {"label": "Discord", "url": "https://discord.gg/X7YGaX76EH"},
+        {"label": "Discord", "url": "https://pyclashbot.app/discord/invite?ref=client"},
     ]
 
     def __init__(self) -> None:

--- a/pyclashbot/utils/discord_rpc.py
+++ b/pyclashbot/utils/discord_rpc.py
@@ -12,7 +12,7 @@ class DiscordRPCManager:
 
     APP_ID = "1181655703446888469"
     BUTTONS = [
-        {"label": "GitHub", "url": "https://github.com/pyclashbot/py-clash-bot"},
+        {"label": "Website", "url": "https://pyclashbot.app"},
         {"label": "Discord", "url": "https://pyclashbot.app/discord/invite?ref=client"},
     ]
 


### PR DESCRIPTION
## What

Replaces the hardcoded `discord.gg/...` invite codes with the site redirect now live at `pyclashbot.app/discord/invite`, so the raw invite codes aren't harvestable from public source (GitHub scrapers, etc.).

| Location | Before | After |
|---|---|---|
| `README.md` (2 links) | `discord.gg/nqKRkyq2UU` | `https://pyclashbot.app/discord/invite` |
| `pyclashbot/utils/discord_rpc.py` (RPC button) | `discord.gg/X7YGaX76EH` | `https://pyclashbot.app/discord/invite?ref=client` |

The redirect is a `302` served by the site (TanStack Start server route). It keeps the two distinct invite codes as redirect targets, and `?ref=client` lets us attribute joins coming from the desktop client's Rich Presence button (separately from README/website traffic).

## Verified

The endpoint is live in production:
- `pyclashbot.app/discord/invite` → 302 → `discord.gg/nqKRkyq2UU`
- `pyclashbot.app/discord/invite?ref=client` → 302 → `discord.gg/X7YGaX76EH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)