### PR TITLE
fix(bluestacks): synthesize MimMetaData.json instead of fragile MIM wait

### DIFF
--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -73,18 +73,11 @@ class BlueStacksEmulatorController(AdbBasedController):
         # Platform-aware config paths
         self.bs_conf_path, self.mim_meta_path = self._find_config_paths()
         if not os.path.isfile(self.mim_meta_path):
+            # Cold installs / BlueStacks Air haven't run the MIM yet; synthesize from bluestacks.conf.
             print(
-                f"[Bluestacks 5] MimMetaData.json not found at {self.mim_meta_path}. Launching Multi-Instance Manager to create it..."
+                f"[Bluestacks 5] MimMetaData.json not found at {self.mim_meta_path}. Synthesizing from bluestacks.conf..."
             )
-            self._open_multi_instance_manager()
-            deadline = time.time() + 10
-            while time.time() < deadline:
-                if os.path.isfile(self.mim_meta_path):
-                    print("[Bluestacks 5] MimMetaData.json detected.")
-                    break
-                interruptible_sleep(0.5)
-            else:
-                raise FileNotFoundError("[Bluestacks 5] MimMetaData.json not created within 10 seconds.")
+            self._synthesize_mim_meta()
         if DEBUG:
             print(f"[Bluestacks 5] bs_conf_path: {self.bs_conf_path}")
             print(f"[Bluestacks 5] mim_meta_path: {self.mim_meta_path}")
@@ -284,6 +277,28 @@ class BlueStacksEmulatorController(AdbBasedController):
                 break
         with open(mim_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=4)
+
+    def _synthesize_mim_meta(self) -> None:
+        """Build a minimal MimMetaData.json from bluestacks.conf's internal<->display mapping."""
+        conf = self._read_text(self.bs_conf_path) or ""
+        org = []
+        for idx, internal in enumerate(self._list_instance_internals(conf)):
+            display = self._get_conf_value(conf, f"bst.instance.{internal}.display_name") or internal
+            org.append(
+                {
+                    "ID": idx,
+                    "Name": display,
+                    "IsFolder": False,
+                    "ParentFolder": -1,
+                    "IsOpen": False,
+                    "IsVisible": True,
+                    "InstanceName": internal,
+                }
+            )
+        os.makedirs(os.path.dirname(self.mim_meta_path), exist_ok=True)
+        with open(self.mim_meta_path, "w", encoding="utf-8") as f:
+            json.dump({"Organization": org}, f, indent=4)
+        print(f"[Bluestacks 5] Synthesized MimMetaData.json with {len(org)} instance(s).")
 
     def _close_multi_instance_manager(self) -> None:
         """Close BlueStacks Multi-Instance Manager if it's open after renaming to update instance name in it."""


### PR DESCRIPTION
## Problem

`BlueStacksEmulatorController.__init__` hard-required `MimMetaData.json` to exist before resolving the managed instance. On a cold BlueStacks install — and with **BlueStacks Air**'s Multi-Instance Manager on macOS — that file doesn't exist yet, so the constructor launched the MIM, waited a **hardcoded 10s**, then raised `FileNotFoundError` with a misleading *"Verify its installation!"* message even on correctly-installed setups. On macOS the MIM rarely writes the file within 10s on first run, so the bot couldn't start.

Closes #693.

## Fix

`MimMetaData.json` is just the MIM's registry mapping internal engine names (e.g. `Tiramisu64`) ↔ display names (e.g. `pyclashbot-136`). `bluestacks.conf` (which exists on any working install) already carries the same mapping, so when the file is missing we now **synthesize it** rather than launch the MIM and wait:

- New `_synthesize_mim_meta()` reads `bluestacks.conf`, enumerates instances via the existing `_list_instance_internals`, and writes one `Organization` entry per instance (display name via `_get_conf_value`, falling back to the internal name).
- The synthesized file matches the exact shape `_update_mim_name()` already writes, so downstream resolution (`_find_internal_by_display_name`, `_ensure_managed_instance`) is unchanged.
- Removed the MIM launch + 10s deadline + `FileNotFoundError` path.

This is option (1) from the issue's proposed fixes — preferred over loosening the timeout, since the MIM never writes the file until it's opened.

## Testing

Verified locally on macOS (BlueStacks Air, Apple Silicon): with no `MimMetaData.json` present, `make dev` → Start now boots BlueStacks and reaches the Clash main menu instead of failing at init. `make lint` passes.