### PR TITLE
test(interface): add UI screenshot capture harness

### DIFF
--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -374,8 +374,13 @@ class PyClashBotUI(ttk.Window):
         self.action_btn.configure(command=self._on_action_pressed)
 
     def _create_jobs_tab(self) -> None:
-        frame = ttk.Labelframe(self.jobs_tab, text="Jobs", padding=10)
-        frame.pack(padx=10, pady=10, anchor="n", fill="x")
+        from ttkbootstrap.scrolled import ScrolledFrame
+
+        scroller = ScrolledFrame(self.jobs_tab, autohide=False)
+        scroller.pack(padx=10, pady=10, fill="both", expand=True)
+        self.jobs_scroller = scroller
+        frame = ttk.Labelframe(scroller, text="Jobs", padding=10)
+        frame.pack(anchor="n", fill="x")
 
         # Fixed columns: job button | inline extras (clan subs) | (i) | spinbox
         col_job, col_inline, col_info, col_spin = 0, 1, 2, 3
@@ -429,30 +434,25 @@ class PyClashBotUI(ttk.Window):
                     command=self._on_clan_chat_master_toggle,
                 )
 
-                sub_frame = ttk.Frame(frame)
-                sub_frame.grid(
-                    row=grid_row + 1,
-                    column=col_job,
-                    columnspan=3,
-                    sticky="w",
-                    padx=(18, 0),
-                    pady=(0, 4),
-                )
-                for col, sub in enumerate(job.sub_jobs):
+                for sub in job.sub_jobs:
+                    grid_row += 1
                     sub_var = ttk.BooleanVar(value=sub.default)
                     sub_checkbox = ttk.Checkbutton(
-                        sub_frame,
+                        frame,
                         text=sub.title,
                         variable=sub_var,
                         command=self._notify_config_change,
+                        width=job_btn_width,
                     )
-                    sub_checkbox.grid(row=0, column=col, sticky="w", padx=(0, 12))
+                    # ttkbootstrap overrides `style=` at construction; reapply after init.
+                    sub_checkbox.configure(style="Purple.Outline.Toolbutton")
+                    sub_checkbox.grid(row=grid_row, column=col_job, sticky="w", pady=2)
                     self.jobs_vars[sub.key] = sub_var
                     self._clan_sub_checkbuttons[sub.key] = sub_checkbox
                     self._trace_variable(sub_var)
                     self._register_config_widget(sub.key.value, sub_checkbox)
                 self._sync_clan_sub_job_widgets_state()
-                grid_row += 2
+                grid_row += 1
 
             elif job.extras:
                 combo_config = next(iter(job.extras.values()))
@@ -481,7 +481,7 @@ class PyClashBotUI(ttk.Window):
                     command=self._notify_config_change,
                     state=READONLY,
                 )
-                spinbox.grid(row=grid_row, column=col_spin, sticky="e")
+                spinbox.grid(row=grid_row, column=col_spin, sticky="e", padx=(0, 4))
                 self._trace_variable(spin_var)
                 self._register_config_widget(combo_field.value, spinbox)
                 self._job_extra_spinboxes[job.key] = spinbox
@@ -767,7 +767,7 @@ class PyClashBotUI(ttk.Window):
         gauge_frame.grid(row=0, column=0, sticky="ew")
         gauge_frame.columnconfigure(0, weight=1)
 
-        self.win_gauge = DualRingGauge(gauge_frame, diameter=80, thickness=10, text_color="#00aaff")
+        self.win_gauge = DualRingGauge(gauge_frame, diameter=58, thickness=8, text_color="#00aaff")
         self.win_gauge.grid(row=0, column=0, pady=(0, 6))
 
         win_loss_frame = ttk.Frame(gauge_frame)
@@ -891,10 +891,6 @@ class PyClashBotUI(ttk.Window):
         )
         self.open_logs_btn.pack(fill="x", pady=(6, 0))
 
-        ttk.Separator(self.misc_tab, orient="horizontal").pack(fill="x", padx=10, pady=(6, 0))
-        display_frame = ttk.Labelframe(self.misc_tab, text="Display settings", padding=10)
-        display_frame.pack(fill="x", padx=10, pady=10)
-
     def _register_config_widget(self, key: str, widget: tk.Widget) -> None:
         self._config_widgets[key] = widget
 
@@ -977,6 +973,30 @@ class PyClashBotUI(ttk.Window):
         gauge_fg = getattr(self._style.colors, "success", "#2ecc71")
         gauge_bg = getattr(self._style.colors, "danger", "#e74c3c")
         self.win_gauge.set_colours(gauge_fg, gauge_bg, foreground)
+        purple = "#a371f7"
+        bg = self._style.lookup("TFrame", "background") or "#222222"
+        self._style.configure(
+            "Purple.Outline.Toolbutton",
+            anchor="center",
+            padding=[10, 5],
+            background=bg,
+            darkcolor=bg,
+            lightcolor=bg,
+            foreground=purple,
+            bordercolor=purple,
+            focuscolor=purple,
+            focusthickness=0,
+            relief="raised",
+        )
+        self._style.map(
+            "Purple.Outline.Toolbutton",
+            foreground=[("disabled", "#646464"), ("pressed", "!disabled", "#ffffff"),
+                        ("selected", "!disabled", "#ffffff"), ("hover", "!disabled", "#ffffff")],
+            background=[("pressed", "!disabled", purple), ("selected", "!disabled", purple),
+                        ("hover", "!disabled", purple)],
+            bordercolor=[("disabled", "#646464"), ("pressed", "!disabled", purple),
+                         ("selected", "!disabled", purple), ("hover", "!disabled", purple)],
+        )
 
     def _on_theme_change(self, _event: object | None = None) -> None:
         self._apply_theme(self.theme_var.get(), skip_variable_update=True)

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -990,12 +990,23 @@ class PyClashBotUI(ttk.Window):
         )
         self._style.map(
             "Purple.Outline.Toolbutton",
-            foreground=[("disabled", "#646464"), ("pressed", "!disabled", "#ffffff"),
-                        ("selected", "!disabled", "#ffffff"), ("hover", "!disabled", "#ffffff")],
-            background=[("pressed", "!disabled", purple), ("selected", "!disabled", purple),
-                        ("hover", "!disabled", purple)],
-            bordercolor=[("disabled", "#646464"), ("pressed", "!disabled", purple),
-                         ("selected", "!disabled", purple), ("hover", "!disabled", purple)],
+            foreground=[
+                ("disabled", "#646464"),
+                ("pressed", "!disabled", "#ffffff"),
+                ("selected", "!disabled", "#ffffff"),
+                ("hover", "!disabled", "#ffffff"),
+            ],
+            background=[
+                ("pressed", "!disabled", purple),
+                ("selected", "!disabled", purple),
+                ("hover", "!disabled", purple),
+            ],
+            bordercolor=[
+                ("disabled", "#646464"),
+                ("pressed", "!disabled", purple),
+                ("selected", "!disabled", purple),
+                ("hover", "!disabled", purple),
+            ],
         )
 
     def _on_theme_change(self, _event: object | None = None) -> None:

--- a/tests/interface/.gitignore
+++ b/tests/interface/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/tests/interface/test_ui_screenshots.py
+++ b/tests/interface/test_ui_screenshots.py
@@ -1,0 +1,136 @@
+"""Enumerate every PyClashBotUI tab/state, screenshot each, save to disk.
+
+UI states captured:
+  - Jobs tab
+  - Emulator tab x 4 sub-states (MEmu, Google Play, BlueStacks, ADB)
+  - Stats tab
+  - Misc tab
+
+Output: tests/interface/screenshots/*.png
+
+Run directly:
+    py tests/interface/test_ui_screenshots.py
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+import time
+from pathlib import Path
+
+from PIL import ImageGrab
+
+from pyclashbot.emulators import EmulatorType
+from pyclashbot.interface.enums import PRIMARY_JOB_TOGGLES, UIField
+from pyclashbot.interface.ui import PyClashBotUI
+
+OUT_DIR = Path(__file__).parent / "screenshots"
+
+
+def _settle(ui: PyClashBotUI, ticks: int = 30, pause_s: float = 0.0) -> None:
+    """Pump the event loop so the requested layout actually paints before we grab."""
+    for _ in range(ticks):
+        ui.update_idletasks()
+        ui.update()
+        if pause_s:
+            time.sleep(pause_s)  # noqa: TID251 — test-only compositor pacing, no worker context here
+
+
+def _grab_window(ui: PyClashBotUI, out_path: Path) -> tuple[int, int]:
+    # Force window to the foreground so nothing composites over it during the grab.
+    ui.lift()
+    ui.attributes("-topmost", True)
+    ui.focus_force()
+    _settle(ui, ticks=20, pause_s=0.01)
+    # Extra settle: Windows compositor needs a beat after a topmost/lift to fully repaint.
+    time.sleep(0.4)  # noqa: TID251 — test-only compositor pacing, no worker context here
+    _settle(ui, ticks=10)
+    x = ui.winfo_rootx()
+    y = ui.winfo_rooty()
+    w = ui.winfo_width()
+    h = ui.winfo_height()
+    img = ImageGrab.grab(bbox=(x, y, x + w, y + h))
+    ui.attributes("-topmost", False)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(out_path)
+    return img.size
+
+
+def _select_tab(ui: PyClashBotUI, text: str) -> None:
+    for tab_id in ui.notebook.tabs():
+        if ui.notebook.tab(tab_id, "text") == text:
+            ui.notebook.select(tab_id)
+            return
+    raise RuntimeError(f"tab not found: {text!r}")
+
+
+def capture_all() -> dict[str, tuple[int, int]]:
+    ui = PyClashBotUI()
+    ui.geometry("490x550+50+50")
+    ui.deiconify()
+    _settle(ui, ticks=60)
+
+    results: dict[str, tuple[int, int]] = {}
+    try:
+        _select_tab(ui, "Jobs")
+        _settle(ui, ticks=20)
+
+        toggleable = [f for f in PRIMARY_JOB_TOGGLES if f in ui.jobs_vars]
+        rng = random.Random(0)
+        scroll_positions = [0.0, 0.5, 1.0]
+        sub_keys = [
+            UIField.CLAN_DONATE_USER_TOGGLE,
+            UIField.CLAN_REQUEST_CARDS_USER_TOGGLE,
+            UIField.CLAN_CLAIM_GIFTS_USER_TOGGLE,
+        ]
+        for idx, frac in enumerate(scroll_positions, start=1):
+            for field in toggleable:
+                ui.jobs_vars[field].set(False)
+            for field in rng.sample(toggleable, k=min(3, len(toggleable))):
+                ui.jobs_vars[field].set(True)
+            # Force Clan chat ON so sub-jobs are enabled and we can see selected + unselected states.
+            ui.jobs_vars[UIField.CLAN_CHAT_USER_TOGGLE].set(True)
+            # Show some subs selected, some not, so both states are captured.
+            for k_idx, k in enumerate(sub_keys):
+                if k in ui.jobs_vars:
+                    ui.jobs_vars[k].set(k_idx == idx - 1)  # one selected, others not
+            ui._on_clan_chat_master_toggle()
+            ui.jobs_scroller.yview_moveto(frac)
+            _settle(ui, ticks=10)
+            label = f"jobs_scroll_{idx}"
+            results[label] = _grab_window(ui, OUT_DIR / f"01_{idx}_jobs_scroll.png")
+
+        _select_tab(ui, "Emulator")
+        emu_states = [
+            ("memu", EmulatorType.MEMU),
+            ("google_play", EmulatorType.GOOGLE_PLAY),
+            ("bluestacks", EmulatorType.BLUESTACKS),
+            ("adb", EmulatorType.ADB),
+        ]
+        for i, (label, emu) in enumerate(emu_states, start=2):
+            ui.emulator_var.set(emu)
+            _settle(ui)
+            results[f"emulator_{label}"] = _grab_window(ui, OUT_DIR / f"{i:02d}_emulator_{label}.png")
+
+        _select_tab(ui, "Stats")
+        results["stats"] = _grab_window(ui, OUT_DIR / "06_stats.png")
+
+        _select_tab(ui, "Misc")
+        results["misc"] = _grab_window(ui, OUT_DIR / "07_misc.png")
+    finally:
+        ui.destroy()
+
+    return results
+
+
+def main() -> int:
+    results = capture_all()
+    print(f"Saved {len(results)} screenshots to {OUT_DIR}:")
+    for name, size in results.items():
+        print(f"  {name}: {size[0]}x{size[1]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `tests/interface/test_ui_screenshots.py`, which boots `PyClashBotUI`, walks every tab + emulator sub-state + three Jobs scroll positions with randomized selections, and writes PNGs under `tests/interface/screenshots/` (gitignored).

@martinmiglio — admittedly a kinda weird test suite (it screenshots a Tk window via `ImageGrab`, so it's Windows-leaning and not a true pytest assertion). I like having it for catching overlapping text / clipped widgets / theme regressions. Fine with merging it, or want me to scrap it? Not a big deal either way.

Stacked on #698 (needs `self.jobs_scroller`).

## Test plan

- [ ] `py tests/interface/test_ui_screenshots.py` — 7 PNGs land in `tests/interface/screenshots/`.
- [ ] Visually scan the PNGs for clipping / bleed-through / orphan widgets.