### PR TITLE
fix(logging): throttle wait loops, polish status messages, and persist worker logs

### DIFF
--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -41,7 +41,7 @@ from pyclashbot.interface.ui import PyClashBotUI, no_jobs_popup
 from pyclashbot.utils.caching import USER_SETTINGS_CACHE
 from pyclashbot.utils.cli_config import arg_parser
 from pyclashbot.utils.discord_rpc import DiscordRPCManager
-from pyclashbot.utils.logger import Logger, initialize_pylogging, log_dir
+from pyclashbot.utils.logger import Logger, initialize_pylogging, log_dir, log_name
 from pyclashbot.utils.open_folder import open_folder
 from pyclashbot.utils.platform import is_macos
 
@@ -207,7 +207,7 @@ def start_button_event(
 
     ui.notebook.select(ui.stats_tab)
 
-    process = WorkerProcess(job_dictionary, stats_queue, shutdown_event)
+    process = WorkerProcess(job_dictionary, stats_queue, shutdown_event, log_name)
     process.start()
     return process
 

--- a/pyclashbot/bot/AGENTS.md
+++ b/pyclashbot/bot/AGENTS.md
@@ -10,6 +10,18 @@
 - Pure detection helpers (`(emulator) → coords | None`) go in `find.py`. Pixel predicates (`check_if_on_*`, `pixel_indicates_*`) go in `state_detect.py`. `find.py` is leaf-only: it never imports from `pyclashbot.bot.*` except `coords` and `state_detect`.
 - New feature jobs go in their own `<feature>_state.py` (see `clan_chat_state.py`, `account_switch.py`, `upgrade_state.py` for the shape). Wire into `states.py:state_tree()` last.
 
+## Status messages
+
+User-facing progress goes through `logger.change_status()` (updates the live status line and log). Use `logger.log()` for detail that should not replace the status line.
+
+- **main menu** — home screen; not "clash main".
+- **Clash Royale** — game/app name (especially emulator startup).
+- **burger menu** — main-menu options overlay.
+- Battle modes: **Classic 1v1**, **Classic 2v2**, **Trophy Road**, **Quick Match**.
+- Use an em dash (`—`) for breaks: `Not on main menu — cannot start fight`.
+- Sentence case; no function names or debug error codes in status text.
+- Throttle repetitive wait-loop messages to ~once per second (see `wait_for_battle_start`, `wait_for_elixir`).
+
 ## Gotchas
 
 - `states.py` carries **module-level globals** (`mode_used_in_1v1`, `fight_mode_cycle_index`) set in one state and read in later ones; if `mode_used_in_1v1` is `None`, fight/cycle states silently skip.

--- a/pyclashbot/bot/account_switch.py
+++ b/pyclashbot/bot/account_switch.py
@@ -43,7 +43,7 @@ def _open_burger_menu_with_retry(emulator, logger: Logger) -> bool:
         if check_if_on_clash_main_burger_button_options_menu(emulator):
             return True
         if not check_if_on_clash_main_menu(emulator):
-            logger.change_status("Not on Clash main menu — cannot open burger menu")
+            logger.change_status("Not on main menu — cannot open burger menu")
             return False
         logger.change_status(f"Opening burger menu (try {attempt}/{BURGER_OPEN_ATTEMPTS})...")
         emulator.click(*CLASH_MAIN_OPTIONS_BURGER_BUTTON)
@@ -105,7 +105,7 @@ def _click_account_slot(emulator, logger: Logger, slot: int) -> bool:
 def switch_account_state(emulator, logger: Logger, account_slot: int) -> bool:
     """Open the account picker and switch to `account_slot` (1-based). Returns True on main menu."""
     if not check_if_on_clash_main_menu(emulator):
-        logger.change_status("Not on Clash main menu — cannot switch accounts")
+        logger.change_status("Not on main menu — cannot switch accounts")
         return False
 
     _settle_main_menu_if_first_switch(logger)

--- a/pyclashbot/bot/card_detection.py
+++ b/pyclashbot/bot/card_detection.py
@@ -10923,19 +10923,16 @@ global battle_iar  # noqa: PLW0604
 play_side = "left"
 
 
-def check_which_cards_are_available(emulator, check_champion=False, check_side=False):
+def check_which_cards_are_available(emulator, check_ability=False, check_side=False):
     global battle_iar
     battle_iar = emulator.screenshot()
     card_exists_list = []
 
-    if check_champion and (
-        check_for_champion_ability(
-            battle_iar[462][324],
-            battle_iar[453][334],
-            battle_iar[462][336],
-        )
-    ):
-        emulator.click(*CHAMPION_ABILITY_DISMISS_COORD)
+    ability_visible = check_ability and check_for_champion_ability(
+        battle_iar[462][324],
+        battle_iar[453][334],
+        battle_iar[462][336],
+    )
 
     if check_side:
         global play_side
@@ -10949,7 +10946,15 @@ def check_which_cards_are_available(emulator, check_champion=False, check_side=F
         if count >= 26:
             card_exists_list.append(i)
 
+    if check_ability:
+        return card_exists_list, ability_visible
+
     return card_exists_list
+
+
+def trigger_hero_champion_ability(emulator, logger) -> None:
+    emulator.click(*CHAMPION_ABILITY_DISMISS_COORD)
+    logger.change_status("Triggered Hero/Champion ability")
 
 
 def check_for_champion_ability(a, b, c):

--- a/pyclashbot/bot/card_mastery_state.py
+++ b/pyclashbot/bot/card_mastery_state.py
@@ -24,15 +24,11 @@ def card_mastery_state(emulator, logger):
     logger.change_status("Going to collect Card Mastery rewards")
 
     if check_if_on_clash_main_menu(emulator) is not True:
-        logger.change_status(
-            'Not on clash main menu for card_mastery_state() returning "restart"',
-        )
+        logger.change_status("Not on main menu — cannot collect Card Mastery rewards")
         return False
 
     if collect_card_mastery_rewards(emulator, logger) is False:
-        logger.change_status(
-            'Failed somewhere in collect_card_mastery_rewards(), returning "restart"',
-        )
+        logger.change_status("Failed to collect Card Mastery rewards")
         return False
 
     return True
@@ -43,7 +39,7 @@ def collect_card_mastery_rewards(emulator, logger: Logger) -> bool:
     logger.change_status("Collecting Card Mastery rewards...")
     if get_to_card_page_from_clash_main(emulator, logger) == "restart":
         logger.change_status(
-            "Failed to get to card page to collect mastery rewards! Returning false",
+            "Failed to open card page for Card Mastery rewards",
         )
         return False
     interruptible_sleep(3)
@@ -63,13 +59,13 @@ def collect_card_mastery_rewards(emulator, logger: Logger) -> bool:
             interruptible_sleep(2)
 
     # get to clash main
-    logger.change_status("Returning to clash main menu")
+    logger.change_status("Returning to main menu")
     emulator.click(CARD_MASTERY_RETURN_TO_MAIN_COORD[0], CARD_MASTERY_RETURN_TO_MAIN_COORD[1])
 
     # wait for main to appear
     if wait_for_clash_main_menu(emulator, logger) is False:
         logger.change_status(
-            "Failed to get back to clash main menu from card page! Returning false",
+            "Timed out returning to main menu from card page",
         )
         return False
 

--- a/pyclashbot/bot/clan_chat_state.py
+++ b/pyclashbot/bot/clan_chat_state.py
@@ -353,6 +353,7 @@ def _recover_clan_chat_from_social(emulator, logger) -> bool:
 def _wait_for_main_after_clan(emulator, logger, timeout: float = 25) -> bool:
     """Return to main from clan/social without generic wait (trophy check false-positives there)."""
     start = time.time()
+    last_social_tab_log_second = -1
     while time.time() - start < timeout:
         if check_if_on_clash_main_menu(emulator):
             return True
@@ -363,7 +364,10 @@ def _wait_for_main_after_clan(emulator, logger, timeout: float = 25) -> bool:
             continue
 
         if check_if_on_social(emulator):
-            logger.change_status("On Social tab — returning to main menu...")
+            elapsed_second = int(time.time() - start)
+            if elapsed_second != last_social_tab_log_second:
+                logger.change_status("On Social tab — returning to main menu...")
+                last_social_tab_log_second = elapsed_second
             if navigate_main_page(emulator, logger, PAGE_SOCIAL, PAGE_MAIN):
                 interruptible_sleep(1)
             continue

--- a/pyclashbot/bot/deck.py
+++ b/pyclashbot/bot/deck.py
@@ -61,12 +61,12 @@ def randomize_and_check_deck(emulator, logger: Logger, deck_to_randomize: int) -
 
 def select_deck_state(emulator, logger: Logger, deck_number, deck_count) -> tuple[bool, int | None]:
     if not check_if_on_clash_main_menu(emulator):
-        logger.change_status("Not on clash main for select_deck_state().")
+        logger.change_status("Not on main menu — cannot select deck")
         return False, None
     logger.change_status(f"Selecting deck #{deck_number}")
     success, selected_deck_number = select_deck(emulator, logger, deck_number, deck_count)
     if not success:
-        logger.change_status("Failed somewhere in select_deck().")
+        logger.change_status("Deck selection failed")
         return False, None
     return True, selected_deck_number
 
@@ -139,7 +139,7 @@ def select_deck(emulator, logger: Logger, deck_number: int, deck_count: int) -> 
 
     success, selected_deck_number = find_and_click_deck(emulator, logger, deck_number, deck_count)
     if not success:
-        logger.change_status("find_and_click_deck() failed.")
+        logger.change_status("Failed to find and select deck")
         return_to_clash_main_from_card_page(emulator, logger)
         return False, None
 
@@ -153,12 +153,12 @@ def select_deck(emulator, logger: Logger, deck_number: int, deck_count: int) -> 
 
 def randomize_deck_state(emulator, logger: Logger, deck_number: int = 2):
     if not check_if_on_clash_main_menu(emulator):
-        logger.change_status("Not on clash main for randomize_deck_state().")
+        logger.change_status("Not on main menu — cannot randomize deck")
         return False
 
     logger.change_status(f"Starting deck randomization state for deck #{deck_number}")
     if not randomize_deck(emulator, logger, deck_number):
-        logger.change_status("Randomize_deck() failed.")
+        logger.change_status("Deck randomization failed")
         return False
 
     return True

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -10,6 +10,7 @@ from pyclashbot.bot.card_detection import (
     create_default_bridge_iar,
     get_play_coords_for_card,
     switch_side,
+    trigger_hero_champion_ability,
 )
 from pyclashbot.bot.coords import (
     CLOSE_BATTLE_LOG_BUTTON,
@@ -39,6 +40,7 @@ from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.logger import Logger
 
 ELIXIR_WAIT_TIMEOUT = 40  # too high but someone got errors with that so idk
+ABILITY_TRIGGER_DELAY_S = 3
 
 
 def do_fight_state(
@@ -51,14 +53,11 @@ def do_fight_state(
 ) -> bool:
     """Handle the entirety of a battle state (start fight, do fight, end fight)."""
 
-    logger.change_status("do_fight_state state")
     logger.change_status("Waiting for battle to start")
 
     # Wait for battle start
     if wait_for_battle_start(emulator, logger) is False:
-        logger.change_status(
-            "Error waiting for battle to start in do_fight_state()",
-        )
+        logger.change_status("Timed out waiting for battle to start")
         return False
 
     logger.change_status("Starting fight loop")
@@ -66,12 +65,12 @@ def do_fight_state(
 
     # Run regular fight loop if random mode not toggled
     if not random_fight_mode and _fight_loop(emulator, logger, recording_flag) is False:
-        logger.change_status("Failure in fight loop")
+        logger.change_status("Fight loop failed")
         return False
 
     # Run random fight loop if random mode toggled
     if random_fight_mode and _random_fight_loop(emulator, logger) is False:
-        logger.change_status("Failure in fight loop")
+        logger.change_status("Fight loop failed")
         return False
 
     # Only log the fight if not called from the start
@@ -116,9 +115,9 @@ def start_fight(emulator, logger, mode) -> bool:
     logger.change_status(f"Starting a {mode} fight")
 
     # Check if on clash main menu
-    logger.log("Checking if on clash main before starting fight...")
+    logger.log("Checking if on main menu before starting fight...")
     if not check_if_on_clash_main_menu(emulator):
-        logger.change_status("Not on clash main menu, cannot start fight")
+        logger.change_status("Not on main menu — cannot start fight")
         return False
 
     # For all modes (1v1 and 2v2), use the same start button
@@ -128,7 +127,7 @@ def start_fight(emulator, logger, mode) -> bool:
 
     # 2v2 needs a second popup after Start
     if mode == "Classic 2v2":
-        logger.change_status("2v2 mode — clicking the quickmatch popup...")
+        logger.change_status("Classic 2v2 — clicking Quick Match popup...")
         interruptible_sleep(3)
         emulator.click(QUICKMATCH_POPUP_BUTTON_COORD[0], QUICKMATCH_POPUP_BUTTON_COORD[1])
         logger.log(f"Clicked Quickmatch button at {QUICKMATCH_POPUP_BUTTON_COORD}")
@@ -138,7 +137,7 @@ def start_fight(emulator, logger, mode) -> bool:
 
 def send_emote(emulator, logger: Logger):
     """Method to do an emote in a fight"""
-    logger.change_status("Hitting an emote")
+    logger.change_status("Sending emote")
 
     # click emote button
     emulator.click(EMOTE_BUTTON_COORD[0], EMOTE_BUTTON_COORD[1])
@@ -151,7 +150,7 @@ def send_emote(emulator, logger: Logger):
 def mag_dump(emulator, logger):
     logger.log("Mag dumping...")
     for index in range(3):
-        logger.change_status(f"mag dump play {index}")
+        logger.change_status(f"Mag dump play {index}")
         card_index = random.randint(0, 3)
         card_coord = MAG_DUMP_CARD_COORDS[card_index]
         play_coord = (random.randint(101, 440), random.randint(50, 526))
@@ -178,6 +177,7 @@ def wait_for_elixir(
     battle_detection_lost_count = 0
     last_logged_second = -1
     last_lost_detection_log_second = -1
+    ability_available_since = None
 
     while not count_elixir(emulator, elixir_wait_amount):
         # debug screenshot saving removed from production
@@ -189,10 +189,23 @@ def wait_for_elixir(
             )
             last_logged_second = elapsed_second
 
-        card_inhand = len(check_which_cards_are_available(emulator, True, False))
+        card_indices, ability_visible = check_which_cards_are_available(emulator, True, False)
+        if ability_visible:
+            if ability_available_since is None:
+                ability_available_since = time.time()
+                logger.change_status(
+                    f"Hero/Champion ability ready — triggering in {ABILITY_TRIGGER_DELAY_S}s",
+                )
+            elif time.time() - ability_available_since >= ABILITY_TRIGGER_DELAY_S:
+                trigger_hero_champion_ability(emulator, logger)
+                ability_available_since = None
+        else:
+            ability_available_since = None
+
+        card_inhand = len(card_indices)
         action_offset, _ = switch_side()
         if action_offset > PLAY_THRESHOLD and card_inhand > 0:
-            logger.change_status("Too much going on, playing now")
+            logger.change_status("Battle too active — playing now")
             return True
 
         if action_offset > WAIT_THRESHOLD and card_inhand == 4:
@@ -205,19 +218,19 @@ def wait_for_elixir(
 
         if not check_for_in_battle_with_delay(emulator):
             if check_if_battle_has_ended(emulator):
-                logger.change_status(status="Not in battle anymore (confirmed), stopping waiting for elixir.")
+                logger.change_status(status="Battle ended — stopping elixir wait")
                 return "no battle"
 
             battle_detection_lost_count += 1
             lost_detection_second = int(time.time())
             if lost_detection_second != last_lost_detection_log_second:
                 logger.change_status(
-                    status="Lost battle detection while waiting for elixir; assuming still in battle.",
+                    status="Lost battle detection while waiting for elixir — assuming still in battle",
                 )
                 last_lost_detection_log_second = lost_detection_second
             if battle_detection_lost_count >= 4:
                 logger.change_status(
-                    status="Lost battle detection repeatedly while waiting for elixir; assuming battle ended.",
+                    status="Lost battle detection repeatedly — assuming battle ended",
                 )
                 return "no battle"
 
@@ -243,12 +256,12 @@ def end_fight_state(
     # count the crown score on this end-battle screen
 
     # get to clash main after this fight
-    logger.log("Getting to clash main after doing a fight")
+    logger.log("Returning to main menu after fight")
     if get_to_main_after_fight(emulator, logger) is False:
-        logger.log("Error 69a3d69 Failed to get to clash main after a fight")
+        logger.log("Failed to return to main menu after fight")
         return False
 
-    logger.log("Made it to clash main after doing a fight")
+    logger.log("Returned to main menu after fight")
     interruptible_sleep(3)
 
     # check if the prev game was a win
@@ -256,7 +269,7 @@ def end_fight_state(
         win_check_return = check_if_previous_game_was_win(emulator, logger)
 
         if win_check_return == "restart":
-            logger.log("Error 885869 Failed while checking if previous game was a win")
+            logger.log("Failed while checking if previous game was a win")
             return False
 
         if win_check_return:
@@ -280,32 +293,29 @@ def check_if_previous_game_was_win(
     logger: Logger,
 ) -> bool | Literal["restart"]:
     """Method to handle the checking if the previous game was a win or loss"""
-    logger.change_status(status="Checking if last game was a win/loss")
+    logger.change_status(status="Checking last game result")
 
     # Use wait_for_clash_main_menu to ensure we are on the main menu.
     if not wait_for_clash_main_menu(emulator, logger, deadspace_click=True):
-        logger.change_status(status='Error Not on main menu, returning "restart"')
+        logger.change_status(status="Not on main menu — cannot check last game result")
         return "restart"
 
     # get to clash main options menu
     if get_to_activity_log(emulator, logger, printmode=False) == "restart":
-        logger.change_status(
-            status="Error 8967203948 get_to_activity_log() in check_if_previous_game_was_win()",
-        )
+        logger.change_status(status="Failed to open battle log")
 
         return "restart"
 
-    logger.change_status(status="Checking if last game was a win...")
+    logger.change_status(status="Checking battle log for win...")
     is_a_win = check_pixels_for_win_in_battle_log(emulator)
-    logger.change_status(status=f"Last game is win: {is_a_win}")
+    result = "win" if is_a_win else "loss"
+    logger.change_status(status=f"Last game result: {result}")
 
     # close battle log
-    logger.change_status(status="Returning to clash main")
+    logger.change_status(status="Returning to main menu")
     emulator.click(CLOSE_BATTLE_LOG_BUTTON[0], CLOSE_BATTLE_LOG_BUTTON[1])
     if wait_for_clash_main_menu(emulator, logger) is False:
-        logger.change_status(
-            status="Error 95867235 wait_for_clash_main_menu() in check_if_previous_game_was_win()",
-        )
+        logger.change_status(status="Timed out returning to main menu after battle log")
         return "restart"
     interruptible_sleep(2)
 
@@ -379,14 +389,14 @@ def play_a_card(emulator, logger, recording_flag: bool, battle_strategy: "Battle
     # click the card index
     click_and_play_card_start_time = time.time()
     if None in [HAND_CARDS_COORDS, card_index]:
-        logger.change_status("[!] Non fatal error: card_index is None")
+        logger.change_status("Non-fatal error: card index is None")
         return False
 
     emulator.click(HAND_CARDS_COORDS[card_index][0], HAND_CARDS_COORDS[card_index][1])
 
     # click the play coord
     if play_coord is None:
-        logger.change_status("[!] Non fatal error: play_coord is None")
+        logger.change_status("Non-fatal error: play coordinates are None")
         return False
 
     emulator.click(play_coord[0], play_coord[1])
@@ -511,14 +521,14 @@ def _fight_loop(emulator, logger: Logger, recording_flag: bool) -> bool:
 
             battle_detection_lost_count += 1
             logger.change_status(
-                f"Lost battle detection mid-fight ({battle_detection_lost_count}); waiting it out.",
+                f"Lost battle detection mid-fight ({battle_detection_lost_count}) — waiting it out",
             )
 
             # If we've lost detection several times in a row, assume the battle
             # ended even if we couldn't confirm it (prevents infinite loops if UI changes).
             if battle_detection_lost_count >= 4:
                 logger.change_status(
-                    "Lost battle detection repeatedly; assuming battle ended.",
+                    "Lost battle detection repeatedly — assuming battle ended",
                 )
                 break
 
@@ -542,7 +552,7 @@ def _fight_loop(emulator, logger: Logger, recording_flag: bool) -> bool:
         )
 
         if wait_output == "restart":
-            logger.change_status("Failure while waiting for elixir")
+            logger.change_status("Failed while waiting for elixir")
             return False
 
         if wait_output == "no battle":
@@ -551,10 +561,10 @@ def _fight_loop(emulator, logger: Logger, recording_flag: bool) -> bool:
 
         if not check_if_in_battle(emulator):
             if check_if_battle_has_ended(emulator):
-                logger.change_status("Not in a battle anymore (confirmed)")
+                logger.change_status("Battle ended (confirmed)")
                 break
 
-            logger.change_status("Lost battle detection; continuing fight loop.")
+            logger.change_status("Lost battle detection — continuing fight loop")
             continue
 
         play_start_time = time.time()
@@ -565,7 +575,7 @@ def _fight_loop(emulator, logger: Logger, recording_flag: bool) -> bool:
             f"Made a play in {str(time.time() - play_start_time)[:4]}s",
         )
 
-    logger.change_status("End of the fight!")
+    logger.change_status("Fight complete")
     interruptible_sleep(2.13)
     cards_played = logger.get_cards_played()
     logger.change_status(f"Played ~{cards_played - prev_cards_played} cards this fight")
@@ -588,12 +598,12 @@ def _random_fight_loop(emulator, logger) -> bool:
 
             battle_detection_lost_count += 1
             logger.change_status(
-                f"Lost battle detection mid-fight ({battle_detection_lost_count}); waiting it out.",
+                f"Lost battle detection mid-fight ({battle_detection_lost_count}) — waiting it out",
             )
 
             if battle_detection_lost_count >= 4:
                 logger.change_status(
-                    "Lost battle detection repeatedly; assuming battle ended.",
+                    "Lost battle detection repeatedly — assuming battle ended",
                 )
                 break
 
@@ -602,7 +612,7 @@ def _random_fight_loop(emulator, logger) -> bool:
 
         battle_detection_lost_count = 0
         if time.time() - start_time > fight_timeout:
-            logger.change_status("_random_fight_loop() timed out. Breaking")
+            logger.change_status("Random fight loop timed out after 5 minutes")
             return False
 
         mag_dump(emulator, logger)
@@ -611,7 +621,7 @@ def _random_fight_loop(emulator, logger) -> bool:
 
         interruptible_sleep(8)
 
-    logger.change_status("Finished with battle with random plays...")
+    logger.change_status("Random-plays fight complete")
     return True
 
 

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -176,13 +176,18 @@ def wait_for_elixir(
     """Method to wait for 4 elixir during a battle"""
     start_time = time.time()
     battle_detection_lost_count = 0
+    last_logged_second = -1
+    last_lost_detection_log_second = -1
 
     while not count_elixir(emulator, elixir_wait_amount):
         # debug screenshot saving removed from production
         wait_time = time.time() - start_time
-        logger.change_status(
-            f"Waiting for {elixir_wait_amount} elixir for {str(wait_time)[:4]}s...",
-        )
+        elapsed_second = int(wait_time)
+        if elapsed_second != last_logged_second:
+            logger.change_status(
+                f"Waiting for {elixir_wait_amount} elixir for {elapsed_second}s...",
+            )
+            last_logged_second = elapsed_second
 
         card_inhand = len(check_which_cards_are_available(emulator, True, False))
         action_offset, _ = switch_side()
@@ -204,9 +209,12 @@ def wait_for_elixir(
                 return "no battle"
 
             battle_detection_lost_count += 1
-            logger.change_status(
-                status="Lost battle detection while waiting for elixir; assuming still in battle.",
-            )
+            lost_detection_second = int(time.time())
+            if lost_detection_second != last_lost_detection_log_second:
+                logger.change_status(
+                    status="Lost battle detection while waiting for elixir; assuming still in battle.",
+                )
+                last_lost_detection_log_second = lost_detection_second
             if battle_detection_lost_count >= 4:
                 logger.change_status(
                     status="Lost battle detection repeatedly while waiting for elixir; assuming battle ended.",

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -64,11 +64,14 @@ def wait_for_battle_start(emulator, logger, timeout: int = 120) -> bool:
         bool: True if battle started, False if timed out.
     """
     start_time = time.time()
+    last_logged_second = -1
     while time.time() - start_time < timeout:
-        time_taken = str(time.time() - start_time)[:4]
-        logger.change_status(
-            status=f"Waiting for battle to start for {time_taken}s",
-        )
+        elapsed_second = int(time.time() - start_time)
+        if elapsed_second != last_logged_second:
+            logger.change_status(
+                status=f"Waiting for battle to start for {elapsed_second}s",
+            )
+            last_logged_second = elapsed_second
 
         # NOTE: Debug screenshot saving was intentionally removed from
         # the production flow. If you need screenshots for debugging,

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -81,7 +81,7 @@ def wait_for_battle_start(emulator, logger, timeout: int = 120) -> bool:
         battle_result = check_if_in_battle(emulator)
 
         if battle_result:  # True for any battle type
-            logger.change_status("Detected an ongoing battle!")
+            logger.change_status("Battle detected")
             return True
 
         emulator.click(x_coord=BATTLE_WAIT_DEADSPACE_COORD[0], y_coord=BATTLE_WAIT_DEADSPACE_COORD[1])
@@ -117,7 +117,7 @@ def handle_trophy_reward_menu(
     printmode=False,
 ) -> Literal["good"]:
     if printmode:
-        logger.change_status(status="Handling trophy reward menu")
+        logger.change_status(status="Handling trophy reward popup")
     else:
         logger.log("Handling trophy reward menu")
     emulator.click(
@@ -143,7 +143,7 @@ def wait_for_clash_main_menu(
     while check_if_on_clash_main_menu(emulator) is not True:
         # timeout check
         if time.time() - start_time > wait_timeout:
-            logger.change_status("Timed out waiting for clash main")
+            logger.change_status("Timed out waiting for main menu")
             break
 
         # handle geting stuck on trophy road screen
@@ -175,7 +175,7 @@ def get_to_card_page_from_clash_main(
 ) -> Literal["restart", "good"]:
     start_time = time.time()
 
-    logger.change_status(status="Getting to card page from clash main")
+    logger.change_status(status="Opening card page from main menu")
 
     # click card page icon
     emulator.click(
@@ -203,11 +203,11 @@ def get_to_card_page_from_clash_main(
 
 def return_to_clash_main_from_card_page(emulator, logger: Logger) -> bool:
     """Click the card page exit button and verify the bot is on the main menu."""
-    logger.change_status("Returning to clash main...")
+    logger.change_status("Returning to main menu...")
     emulator.click(*CARD_PAGE_EXIT_BUTTON_COORDS)
     interruptible_sleep(1)
     if not check_if_on_clash_main_menu(emulator):
-        logger.change_status("Failed to return to clash main from the card page.")
+        logger.change_status("Failed to return to main menu from card page")
         return False
     return True
 
@@ -215,19 +215,19 @@ def return_to_clash_main_from_card_page(emulator, logger: Logger) -> bool:
 def open_clash_main_options_menu(emulator, logger: Logger, printmode: bool = False) -> bool:
     """Open the burger menu from the Clash main screen. Returns False if not on main or menu never opens."""
     if check_if_on_clash_main_menu(emulator) is not True:
-        logger.change_status(status="Not on clash main menu")
+        logger.change_status(status="Not on main menu")
         return False
 
     if printmode:
-        logger.change_status(status="Opening clash main options menu")
+        logger.change_status(status="Opening burger menu")
     else:
-        logger.log("Opening clash main options menu")
+        logger.log("Opening burger menu")
     emulator.click(
         CLASH_MAIN_OPTIONS_BURGER_BUTTON[0],
         CLASH_MAIN_OPTIONS_BURGER_BUTTON[1],
     )
     if wait_for_clash_main_burger_button_options_menu(emulator, logger, printmode) == "restart":
-        logger.change_status(status="Timed out waiting for clash main options menu")
+        logger.change_status(status="Timed out waiting for burger menu")
         return False
     return True
 
@@ -252,9 +252,7 @@ def get_to_activity_log(
         logger.log("Clicking activity log button")
     emulator.click(BATTLE_LOG_BUTTON[0], BATTLE_LOG_BUTTON[1])
     if wait_for_battle_log_page(emulator, logger, printmode) == "restart":
-        logger.change_status(
-            status="Error 923593 Waited too long for battle log page, restarting vm",
-        )
+        logger.change_status(status="Timed out waiting for battle log page")
         return "restart"
 
     return "good"
@@ -273,9 +271,7 @@ def wait_for_battle_log_page(
     while not check_if_on_battle_log_page(emulator):
         time_taken = time.time() - start_time
         if time_taken > 20:
-            logger.change_status(
-                status="Error 2457245645 Waiting too long for battle log page",
-            )
+            logger.change_status(status="Timed out waiting for battle log page")
             return "restart"
 
     if printmode:
@@ -308,47 +304,57 @@ def wait_for_clash_main_burger_button_options_menu(
     start_time = time.time()
 
     if printmode:
-        logger.change_status(status="Waiting for clash main options menu to appear")
+        logger.change_status(status="Waiting for burger menu to appear")
     else:
-        logger.log("Waiting for clash main options menu to appear")
+        logger.log("Waiting for burger menu to appear")
     while not check_if_on_clash_main_burger_button_options_menu(emulator):
         time_taken = time.time() - start_time
         if time_taken > 20:
-            logger.change_status(
-                status="Error 57245645362 Waiting too long for clash main options menu to appear",
-            )
+            logger.change_status(status="Timed out waiting for burger menu")
             return "restart"
     if printmode:
-        logger.change_status(
-            status="Done waiting for clash main options menu to appear",
-        )
+        logger.change_status(status="Burger menu open")
     else:
-        logger.log("Done waiting for clash main options menu to appear")
+        logger.log("Burger menu open")
     return "good"
 
 
-def select_mode(emulator, mode: str):
+def select_mode(emulator, mode: str, logger: Logger | None = None):
     # Check if the mode is valid
     expected_mode_types = ["Classic 1v1", "Classic 2v2", "Trophy Road"]
     if type(mode) is not str:
-        print(f'[!] Warning: Mode "{mode}" is not a string. Expected a string.')
+        msg = f'[!] Warning: Mode "{mode}" is not a string. Expected a string.'
+        if logger is not None:
+            logger.change_status(msg)
+        else:
+            print(msg)
         return False
 
     # Check if the mode is valid
     if mode not in expected_mode_types:
-        print(f'[!] Warning: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.')
+        msg = f'[!] Warning: Mode "{mode}" is not a valid mode type. Expected one of {expected_mode_types}.'
+        if logger is not None:
+            logger.change_status(msg)
+        else:
+            print(msg)
         return False
 
     # must be on clash main
     if not check_if_on_clash_main_menu(emulator):
-        print("[!] Not on clash main menu, cannot select a fight mode")
+        msg = "Not on main menu — cannot select battle mode"
+        if logger is not None:
+            logger.change_status(msg)
+        else:
+            print(f"[!] {msg}")
         return False
+
+    if logger is not None:
+        logger.change_status(f"Selecting {mode}...")
 
     # open fight type selection menu
     game_mode_coord = [308, 485]
 
     # click select mode button
-    print("Clicking mode selection button")
     emulator.click(game_mode_coord[0], game_mode_coord[1])
     interruptible_sleep(2)
 
@@ -368,7 +374,6 @@ def select_mode(emulator, mode: str):
     while time.time() - start_time < search_timeout:
         coord = find_fight_mode_icon(emulator, mode)
         if coord is not None:
-            print(f'Located the "{mode}" button, clicking it.')
             emulator.click(*coord)
             interruptible_sleep(3)
 
@@ -382,10 +387,14 @@ def select_mode(emulator, mode: str):
                 # Don't fail if the click doesn't work; best-effort only.
                 pass
 
+            if logger is not None:
+                logger.change_status(f"Selected {mode}")
             return True
 
         scroll_down_in_fight_mode_panel(emulator)
 
+    if logger is not None:
+        logger.change_status(f"Failed to find {mode} in mode panel")
     return False
 
 
@@ -499,36 +508,33 @@ def get_to_main_after_fight(emulator, logger):
     start_time = time.time()
     clicked_ok_or_exit = False
 
-    logger.change_status("Returning to clash main after the fight...")
+    logger.change_status("Returning to main menu after fight...")
 
     while time.time() - start_time < timeout:
         if check_if_on_clash_main_menu(emulator) is True:
             interruptible_sleep(3)
 
             if check_for_trophy_reward_menu(emulator):
-                print("Found trophy reward menu")
-                handle_trophy_reward_menu(emulator, logger, printmode=False)
+                handle_trophy_reward_menu(emulator, logger, printmode=True)
                 interruptible_sleep(2)
 
-            print("Made it to clash main after a fight")
+            logger.change_status("Returned to main menu after fight")
             return True
 
         if check_for_trophy_reward_menu(emulator):
-            print("Found trophy reward menu!\nHandling Trophy Reward Menu")
-            handle_trophy_reward_menu(emulator, logger, printmode=False)
+            handle_trophy_reward_menu(emulator, logger, printmode=True)
             interruptible_sleep(3)
             continue
 
         if not clicked_ok_or_exit:
             button_coord = find_post_battle_button(emulator)
             if button_coord is not None:
-                print("Found post-battle button, clicking it.")
+                logger.change_status("Clicking post-battle button")
                 emulator.click(button_coord[0], button_coord[1])
                 clicked_ok_or_exit = True
                 continue
 
         interruptible_sleep(1)
-        print("Clicking on deadspace to close potential pop-up windows.")
         emulator.click(CLASH_MAIN_MENU_DEADSPACE_COORD[0], CLASH_MAIN_MENU_DEADSPACE_COORD[1])
 
     return False

--- a/pyclashbot/bot/shop_daily_state.py
+++ b/pyclashbot/bot/shop_daily_state.py
@@ -60,7 +60,7 @@ def shop_daily_state(emulator, logger: Logger) -> bool:
         _paginate_shop(emulator)
 
     if found is None:
-        logger.change_status("Daily free shop offer not found — returning to main")
+        logger.change_status("Daily free shop offer not found — returning to main menu")
         return navigate_main_page(emulator, logger, PAGE_SHOP, PAGE_MAIN)
 
     logger.change_status(f"Found daily free offer at {found}, claiming...")

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -43,7 +43,7 @@ def handle_state_failure(logger: Logger, state_name: str, function_name: str, er
         full_msg += f": {error_msg}"
 
     logger.error(full_msg)
-    logger.change_status(f"Error in {state_name} - restarting")
+    logger.change_status(f"Error in {state_name} — restarting")
     print(f"[ERROR] {full_msg}")
 
     return "restart"
@@ -272,6 +272,7 @@ def state_tree(
         return state_order.next_state(state)
 
     if state == "restart":
+        logger.change_status("Restarting emulator...")
         logger.add_restart_after_failure()
         emulator.restart()
         return state_order.next_state(state)
@@ -450,9 +451,9 @@ def state_tree(
         # if more than one mode is selected, just cycle through them
         if len(enabled_modes) > 1:
             selected_mode = get_next_fight_mode(job_list)
-            print(f"Multiple modes enabled. Selected {selected_mode} as the next battle mode")
+            logger.change_status(f"Selected {selected_mode} as the next battle mode")
             mode_used_in_1v1 = selected_mode
-            if select_mode(emulator, selected_mode) is False:
+            if select_mode(emulator, selected_mode, logger) is False:
                 return handle_state_failure(
                     logger, "select_battle_mode", "select_mode", f"Failed to select mode: {selected_mode}"
                 )
@@ -460,15 +461,13 @@ def state_tree(
             # if only one mode is selected, check if it's already selected
             selected_mode = enabled_modes[0]
             mode_used_in_1v1 = selected_mode
-            print(f"Only one mode enabled: {selected_mode}. Checking if it's selected.")
             if not check_if_battle_mode_is_selected(emulator, selected_mode):
-                print(f"{selected_mode} is not selected. Selecting it now.")
-                if select_mode(emulator, selected_mode) is False:
+                if select_mode(emulator, selected_mode, logger) is False:
                     return handle_state_failure(
                         logger, "select_battle_mode", "select_mode", f"Failed to select mode: {selected_mode}"
                     )
             else:
-                print(f"{selected_mode} is already selected.")
+                logger.change_status(f"{selected_mode} is already selected")
 
         return state_order.next_state(state)
 

--- a/pyclashbot/bot/upgrade_state.py
+++ b/pyclashbot/bot/upgrade_state.py
@@ -99,7 +99,7 @@ def upgrade_card(emulator, upgradable, logger: Logger):
         pixel = img[COIN_INSUFFICIENT_COORD[1]][COIN_INSUFFICIENT_COORD[0]]
         if pixel_is_equal(pixel, COIN_INSUFFICIENT_BGR, UPGRADE_PIXEL_TOLERANCE):
             logger.log("Cannot upgrade this card: not enough coins")
-            logger.change_status(status="Not enough coins passing")
+            logger.change_status(status="Not enough coins — skipping card")
 
         else:
             logger.log("Upgraded a card!")
@@ -136,18 +136,16 @@ def upgrade_card(emulator, upgradable, logger: Logger):
 
 
 def upgrade_cards_state(emulator, logger: Logger):
-    logger.change_status(status="Upgrade cards state")
+    logger.change_status(status="Upgrading cards")
 
     # if not on clash main, return restart
     print("Making sure on clash main before upgrading cards")
 
     if not check_if_on_clash_main_menu(emulator):
-        logger.change_status("Not on Clash main menu at start of upgrade_cards_state()")
+        logger.change_status("Not on main menu — cannot upgrade cards")
         return False
 
-    # select Trophy Road mode
-    logger.change_status(status="Selecting Trophy Road mode")
-    if not select_mode(emulator, "Trophy Road"):
+    if not select_mode(emulator, "Trophy Road", logger):
         logger.change_status("Failed to select Trophy Road mode")
         return False
 
@@ -155,7 +153,7 @@ def upgrade_cards_state(emulator, logger: Logger):
     logger.change_status(status="Getting to card page")
     if get_to_card_page_from_clash_main(emulator, logger) == "restart":
         logger.change_status(
-            status="Error 0751389: Failed to get to card page from Clash main in Upgrade State",
+            status="Failed to open card page from main menu",
         )
         return False
 
@@ -176,7 +174,7 @@ def upgrade_cards_state(emulator, logger: Logger):
     interruptible_sleep(2)
 
     if not wait_for_clash_main_menu(emulator, logger, deadspace_click=False):
-        logger.change_status("Failed to wait for Clash main menu after upgrading cards")
+        logger.change_status("Timed out waiting for main menu after upgrading cards")
         return False
 
     logger.update_time_of_last_card_upgrade(time.time())

--- a/pyclashbot/bot/war.py
+++ b/pyclashbot/bot/war.py
@@ -57,7 +57,7 @@ _WAR_POST_BATTLE_DISMISS_TIMEOUT_S = 60.0
 def make_war_deck(emulator, logger, deck_index: int) -> bool:
     """Open empty war-deck slot `deck_index`, randomize it, exit. 1 <= index <= 4."""
     if deck_index not in _MAKE_WAR_DECK_COORDS:
-        logger.change_status(f"make_war_deck: invalid deck_index {deck_index}")
+        logger.change_status(f"Invalid war deck index: {deck_index}")
         return False
 
     logger.change_status(f"Making war deck #{deck_index}...")
@@ -84,10 +84,10 @@ def war_battle_loop(emulator, logger) -> bool:
 
             battle_detection_lost_count += 1
             logger.change_status(
-                f"Lost war battle detection ({battle_detection_lost_count}); waiting it out.",
+                f"Lost war battle detection ({battle_detection_lost_count}) — waiting it out",
             )
             if battle_detection_lost_count >= 4:
-                logger.change_status("Lost war battle detection repeatedly; assuming battle ended.")
+                logger.change_status("Lost war battle detection repeatedly — assuming battle ended")
                 break
 
             interruptible_sleep(1)
@@ -95,7 +95,7 @@ def war_battle_loop(emulator, logger) -> bool:
 
         battle_detection_lost_count = 0
         if time.time() - start_time > _WAR_BATTLE_LOOP_TIMEOUT_S:
-            logger.change_status("war_battle_loop: timed out after 5 minutes")
+            logger.change_status("War battle timed out after 5 minutes")
             return False
 
         card = random.choice(HAND_CARDS_COORDS)
@@ -203,7 +203,7 @@ def war_state(emulator, logger) -> bool:
         emulator.click(*WAR_DEADSPACE_COORD)
         interruptible_sleep(1)
         if not navigate_main_page(emulator, logger, PAGE_WAR, PAGE_MAIN):
-            logger.change_status("Failed to return to main from war")
+            logger.change_status("Failed to return to main menu from war")
             return False
         interruptible_sleep(1)
         return check_if_on_clash_main_menu(emulator)
@@ -224,7 +224,7 @@ def war_state(emulator, logger) -> bool:
             return False
 
     if not navigate_main_page(emulator, logger, PAGE_WAR, PAGE_MAIN):
-        logger.change_status("Failed to return to main from war")
+        logger.change_status("Failed to return to main menu from war")
         return False
     interruptible_sleep(1)
     return check_if_on_clash_main_menu(emulator)

--- a/pyclashbot/bot/worker.py
+++ b/pyclashbot/bot/worker.py
@@ -6,7 +6,7 @@ from pyclashbot.bot.states import StateHistory, StateOrder, state_tree
 from pyclashbot.emulators import EmulatorType, get_emulator_registry
 from pyclashbot.interface.enums import UIField
 from pyclashbot.utils.cancellation import CancellationToken
-from pyclashbot.utils.logger import ProcessLogger
+from pyclashbot.utils.logger import ProcessLogger, attach_worker_file_logging
 from pyclashbot.utils.platform import is_macos
 
 
@@ -22,11 +22,13 @@ class WorkerProcess(Process):
         jobs: dict[str, Any],
         stats_queue: Queue,
         shutdown_event: Event,
+        session_log_path: str,
     ) -> None:
         super().__init__(daemon=True)
         self.jobs = jobs
         self.stats_queue = stats_queue
         self.shutdown_event = shutdown_event
+        self.session_log_path = session_log_path
 
     def _setup_emulator(self, jobs: dict[str, Any], logger: ProcessLogger):
         """Set up the appropriate emulator based on job configuration."""
@@ -130,6 +132,7 @@ class WorkerProcess(Process):
     def run(self) -> None:
         """Main worker process execution."""
         print("WorkerProcess run()...")
+        attach_worker_file_logging(self.session_log_path)
 
         # Set up cancellation token for interruptible sleeps
         token = CancellationToken(self.shutdown_event)

--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -692,7 +692,7 @@ class BlueStacksEmulatorController(AdbBasedController):
                 return True
             self.click(35, 405)  # Use inherited click
 
-        self.logger.change_status("Timeout waiting for Clash main menu - retrying...")
+        self.logger.change_status("Timeout waiting for Clash Royale main menu — retrying...")
         return False
 
     # click() is now inherited from AdbBasedController

--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -414,7 +414,7 @@ class GooglePlayEmulatorController(AdbBasedController):
             # if found main in time, break
             if check_if_on_clash_main_menu(self) is True:
                 self.logger.change_status("Clash Royale main menu detected successfully!")
-                self.logger.log("Detected clash main!")
+                self.logger.log("Clash Royale main menu detected")
                 break
 
             # click deadspace

--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -1335,7 +1335,7 @@ class MemuEmulatorController(BaseEmulatorController):
                         self.logger.log(f"[RESTART] Total wait time: {elapsed_wait:.1f}s")
                         self.logger.log(f"[RESTART] Total restart time: {total_elapsed}s")
 
-                    self.logger.change_status("Clash main menu detected!")
+                    self.logger.change_status("Clash Royale main menu detected")
                     self.logger.log(f"Emulator restart completed in {total_elapsed}s")
 
                     if debug_restart:
@@ -1372,7 +1372,7 @@ class MemuEmulatorController(BaseEmulatorController):
                 self.logger.log(f"[RESTART] Loop iterations: {loop_iteration}")
                 self.logger.log("[RESTART] INITIATING RECURSIVE RESTART DUE TO TIMEOUT")
 
-            self.logger.change_status("Timeout waiting for Clash main menu, restarting...")
+            self.logger.change_status("Timeout waiting for Clash Royale main menu — restarting...")
             return self.restart(open_clash=open_clash, start_time=start_time)
 
         # If not opening Clash, we're done

--- a/pyclashbot/utils/logger.py
+++ b/pyclashbot/utils/logger.py
@@ -8,7 +8,7 @@ import time
 import zipfile
 from functools import wraps
 from os import listdir, makedirs, remove
-from os.path import basename, exists, getmtime, join
+from os.path import abspath, basename, exists, getmtime, join, normcase
 
 from pyclashbot.utils.platform import get_log_dir
 from pyclashbot.utils.versioning import __version__
@@ -39,31 +39,45 @@ def compress_logs() -> None:
                 remove(log)
 
 
-def initialize_pylogging() -> None:
-    """Method to be called once to initialize python logging"""
+def _normalized_log_path(path: str) -> str:
+    return normcase(abspath(path))
+
+
+def _attach_log_file_handler(log_path: str) -> None:
+    """Attach a log-file handler if this process does not already have one for log_path."""
     if not exists(log_dir):
         makedirs(log_dir)
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
 
-    # Ensure we always have a file handler, even if something logged earlier (which would
-    # make logging.basicConfig(...) a no-op).
-    already_has_log_file = False
+    target_log = _normalized_log_path(log_path)
     for handler in root_logger.handlers:
         if isinstance(handler, logging.FileHandler):
             try:
-                if handler.baseFilename == log_name:
-                    already_has_log_file = True
-                    break
+                if _normalized_log_path(handler.baseFilename) == target_log:
+                    return
             except Exception:
                 continue
 
-    if not already_has_log_file:
-        file_handler = logging.FileHandler(log_name, encoding="utf-8")
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(logging.Formatter("%(levelname)s:%(asctime)s %(message)s"))
-        root_logger.addHandler(file_handler)
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(logging.Formatter("%(levelname)s:%(asctime)s %(message)s"))
+    root_logger.addHandler(file_handler)
+
+
+def attach_worker_file_logging(session_log_path: str) -> None:
+    """Attach file logging in the bot worker subprocess.
+
+    macOS/Windows use spawn for multiprocessing, so the worker does not inherit
+    the GUI process's logging handlers.
+    """
+    _attach_log_file_handler(session_log_path)
+
+
+def initialize_pylogging() -> None:
+    """Method to be called once to initialize python logging"""
+    _attach_log_file_handler(log_name)
 
     logging.info("Logging initialized for %s", __version__)
     logging.info("Log directory: %s", log_dir)

--- a/tests/clash_royale/jobs/test_select_battle_mode.py
+++ b/tests/clash_royale/jobs/test_select_battle_mode.py
@@ -26,7 +26,7 @@ def run_test(emulator, logger) -> tuple[bool, str]:
         return (False, "Didn't begin on clash main")
 
     for mode in MODES:
-        if select_mode(emulator, mode) is False:
+        if select_mode(emulator, mode, logger) is False:
             return (False, f"Failed during select_mode({mode!r})")
         if not wait_for_clash_main_menu(emulator, logger):
             return (False, f"Didn't return to clash main after select_mode({mode!r})")


### PR DESCRIPTION
## Summary
- Throttle repetitive wait-loop status messages (`wait_for_battle_start`, `wait_for_elixir`, clan social-tab recovery) to at most once per second without changing poll timing
- Log Hero/Champion ability detection with a 3s delay before triggering, plus status for mode selection, post-battle navigation, and emulator restarts
- Standardize user-facing status wording (main menu, burger menu, battle mode names, em dashes) and remove function names/debug codes from status text
- **Fix session log files missing bot activity:** `WorkerProcess` runs in a spawned subprocess (macOS/Windows) and did not inherit the GUI process's `FileHandler`, so `~/Library/Logs/py-clash-bot/*.txt` only had startup/job-dict/stop lines while the terminal had the full run. The worker now attaches to the same session log path passed from the GUI process.
- Document status-message conventions in `pyclashbot/bot/AGENTS.md`

## What reviewers should focus on
- **Wait-loop throttling** (`nav.py`, `fight.py`, `clan_chat_state.py`): poll loops unchanged; only `change_status` frequency is capped via `last_log_time`
- **Worker log persistence** (`logger.py`, `worker.py`, `__main__.py`): small helper `attach_worker_file_logging()`; no duplicate startup banner in the worker; `log_name` passed from parent so stop/start in one app session stays in one file
- **Status polish** (`bot/`, emulators): user-facing strings only; no behavior changes except ability trigger delay and throttled logging

## Test plan
- [ ] Run a 2v2 fight — wait-loop messages appear ~1/s, not many per second
- [ ] Confirm battle start, elixir wait, and card plays still work normally
- [ ] With a Hero/Champion in deck, confirm ability ready/triggered messages and ~3s delay
- [ ] After a fight, confirm post-battle status lines (trophy popup, post-battle button, returned to main menu)
- [ ] Run clan chat jobs and confirm social-tab recovery still works
- [ ] Spot-check mode selection status when cycling Classic 1v1 / 2v2 / Trophy Road
- [ ] **Log file check:** after a bot run, open `~/Library/Logs/py-clash-bot/<session>.txt` and confirm fight/clan/restart lines appear (not just start/stop)