### PR TITLE
fix(logging): PR 702 review follow-ups

### DIFF
--- a/pyclashbot/bot/card_detection.py
+++ b/pyclashbot/bot/card_detection.py
@@ -11665,11 +11665,20 @@ play_side = "left"
 
 def is_hero_champion_ability_visible(emulator) -> bool:
     iar = emulator.screenshot()
-    return check_for_champion_ability(
-        iar[462][324],
-        iar[453][334],
-        iar[462][336],
+    pixels = numpy.array([iar[462][324], iar[453][334], iar[462][336]])
+    colors = numpy.array(
+        [
+            [215, 28, 223],
+            [240, 39, 254],
+            [239, 40, 251],
+        ],
     )
+
+    for p in pixels:
+        if numpy.any(numpy.all(numpy.abs(colors - p) <= 30, axis=1)):
+            return True
+
+    return False
 
 
 def check_which_cards_are_available(emulator, check_side=False):
@@ -11695,23 +11704,6 @@ def check_which_cards_are_available(emulator, check_side=False):
 def trigger_hero_champion_ability(emulator, logger) -> None:
     emulator.click(*CHAMPION_ABILITY_DISMISS_COORD)
     logger.change_status("Triggered Hero/Champion ability")
-
-
-def check_for_champion_ability(a, b, c):
-    pixels = numpy.array([a, b, c])
-    colors = numpy.array(
-        [
-            [215, 28, 223],
-            [240, 39, 254],
-            [239, 40, 251],
-        ],
-    )
-
-    for p in pixels:
-        if numpy.any(numpy.all(numpy.abs(colors - p) <= 30, axis=1)):
-            return True
-
-    return False
 
 
 def identify_hand_cards(emulator, card_index):

--- a/pyclashbot/bot/card_detection.py
+++ b/pyclashbot/bot/card_detection.py
@@ -11663,16 +11663,19 @@ global battle_iar  # noqa: PLW0604
 play_side = "left"
 
 
-def check_which_cards_are_available(emulator, check_ability=False, check_side=False):
+def is_hero_champion_ability_visible(emulator) -> bool:
+    iar = emulator.screenshot()
+    return check_for_champion_ability(
+        iar[462][324],
+        iar[453][334],
+        iar[462][336],
+    )
+
+
+def check_which_cards_are_available(emulator, check_side=False):
     global battle_iar
     battle_iar = emulator.screenshot()
     card_exists_list = []
-
-    ability_visible = check_ability and check_for_champion_ability(
-        battle_iar[462][324],
-        battle_iar[453][334],
-        battle_iar[462][336],
-    )
 
     if check_side:
         global play_side
@@ -11685,9 +11688,6 @@ def check_which_cards_are_available(emulator, check_ability=False, check_side=Fa
         count = numpy.sum(purple_pixels)
         if count >= 26:
             card_exists_list.append(i)
-
-    if check_ability:
-        return card_exists_list, ability_visible
 
     return card_exists_list
 

--- a/pyclashbot/bot/clan_chat_state.py
+++ b/pyclashbot/bot/clan_chat_state.py
@@ -353,7 +353,6 @@ def _recover_clan_chat_from_social(emulator, logger) -> bool:
 def _wait_for_main_after_clan(emulator, logger, timeout: float = 25) -> bool:
     """Return to main from clan/social without generic wait (trophy check false-positives there)."""
     start = time.time()
-    last_social_tab_log_second = -1
     while time.time() - start < timeout:
         if check_if_on_clash_main_menu(emulator):
             return True
@@ -364,12 +363,9 @@ def _wait_for_main_after_clan(emulator, logger, timeout: float = 25) -> bool:
             continue
 
         if check_if_on_social(emulator):
-            elapsed_second = int(time.time() - start)
-            if elapsed_second != last_social_tab_log_second:
-                logger.change_status("On Social tab — returning to main menu...")
-                last_social_tab_log_second = elapsed_second
             if navigate_main_page(emulator, logger, PAGE_SOCIAL, PAGE_MAIN):
-                interruptible_sleep(1)
+                logger.change_status("On Social tab — returning to main menu...")
+                interruptible_sleep(3)
             continue
 
         if (

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -9,6 +9,7 @@ from pyclashbot.bot.card_detection import (
     check_which_cards_are_available,
     create_default_bridge_iar,
     get_play_coords_for_card,
+    is_hero_champion_ability_visible,
     switch_side,
     trigger_hero_champion_ability,
 )
@@ -189,8 +190,8 @@ def wait_for_elixir(
             )
             last_logged_second = elapsed_second
 
-        card_indices, ability_visible = check_which_cards_are_available(emulator, True, False)
-        if ability_visible:
+        card_indices = check_which_cards_are_available(emulator)
+        if is_hero_champion_ability_visible(emulator):
             if ability_available_since is None:
                 ability_available_since = time.time()
                 logger.change_status(
@@ -356,7 +357,7 @@ def play_a_card(emulator, logger, recording_flag: bool, battle_strategy: "Battle
     # check which cards are available
     logger.change_status("Looking at which cards are available")
     available_card_check_start_time = time.time()
-    card_indices = check_which_cards_are_available(emulator, False, True)
+    card_indices = check_which_cards_are_available(emulator, check_side=True)
 
     if not card_indices:
         logger.change_status("No cards ready yet...")

--- a/tests/test_card_fingerprint_bgr.py
+++ b/tests/test_card_fingerprint_bgr.py
@@ -45,7 +45,7 @@ def test_bot_uses_raw_bgr_screenshot() -> None:
 
 def test_bgr_path_identifies_hand() -> None:
     bgr = _load_bgr()
-    cd.check_which_cards_are_available(_BgrEmulator(bgr), False, False)
+    cd.check_which_cards_are_available(_BgrEmulator(bgr))
     for slot, expected in EXPECTED.items():
         corners = cd.get_all_pixel_data(None, slot)
         raw = cd.find_closest_card(corners)


### PR DESCRIPTION
## Summary
- Extract hero/champion ability detection into `is_hero_champion_ability_visible()`; `wait_for_elixir` calls it directly instead of bundling it into `check_which_cards_are_available`
- Replace social-tab log throttling in `_wait_for_main_after_clan` with log-on-navigate + 3s post-nav sleep

Follow-up to #702 review threads #3 and #4. Left `check_ability` naming as-is per discussion (#2) — shared Hero/Champion pixel check.

## Test plan
- [ ] `make test`
- [ ] Run clan chat jobs — confirm no repeated "On Social tab" spam when returning to main
- [ ] Run a fight with a Hero/Champion in deck — ability ready/triggered logs still appear


Made with [Cursor](https://cursor.com)