### PR TITLE
fix(emulators): enforce BlueStacks balanced mode and disable cosmetic toggles

### DIFF
--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -465,6 +465,11 @@ class BlueStacksEmulatorController(AdbBasedController):
             conf = self._set_conf_value(conf, "bst.enable_adb_access", "1")
             changed = True
 
+        # Ensure balanced performance mode (0 = balanced)
+        if (self._get_conf_value(conf, "bst.mem_opt_mode") or "0") != "0":
+            conf = self._set_conf_value(conf, "bst.mem_opt_mode", "0")
+            changed = True
+
         # Ensure custom resolution entry exists
         new_conf = self._ensure_custom_resolution(conf, "418 x 633")
         if new_conf != conf:
@@ -479,6 +484,9 @@ class BlueStacksEmulatorController(AdbBasedController):
             f"bst.instance.{internal}.dpi": "160",
             f"bst.instance.{internal}.max_fps": "40",
             f"bst.instance.{internal}.custom_resolution_selected": "1",
+            f"bst.instance.{internal}.enable_high_fps": "0",
+            f"bst.instance.{internal}.enable_vsync": "0",
+            f"bst.instance.{internal}.enable_fps_display": "0",
         }
         if ensure_display:
             desired[f"bst.instance.{internal}.display_name"] = self.instance_name


### PR DESCRIPTION
Enforces balanced performance mode and disables high FPS, VSync, and FPS display overlays on every bot start.

Same pattern as existing CPU/RAM/FPS/ADB settings — written to `bluestacks.conf` via `_compose_instance_conf()`.

**Why these defaults:**

- **Balanced performance mode** — High performance mode wastes resources and runs hot (not needed for the bot's use case)
- **High FPS off** — the bot caps at 40 FPS via `max_fps`. Allowing higher FPS just wastes GPU cycles with no benefit to detection speed.
- **VSync off** — the bot uses ADB screencap which reads the framebuffer directly, so screen tearing doesn't affect image recognition.
- **FPS display off** — overlays on screen can interfere with the bot's pixel checks and image matching.

Changes:
- `bst.mem_opt_mode` → `0` (balanced) — global setting
- `bst.instance.<N>.enable_high_fps` → `0`
- `bst.instance.<N>.enable_vsync` → `0`
- `bst.instance.<N>.enable_fps_display` → `0`