### PR TITLE
refactor(emulators): split cheap construct from booting restart() [2/3]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ A Clash Royale automation bot: drives an Android emulator via ADB and acts on th
 ## Commands
 
 Targets live in the `Makefile` (`make setup`/`dev`/`lint`/`test`, `build-msi`/`build-dmg`, all via `uv`); `CONTRIBUTING.md` has dev setup. Non-obvious bits those don't tell you:
-- Tests are **pytest**, offline by default (`addopts = -m "not emulator"`). Hardware tests carry `@pytest.mark.emulator`: `make test` runs only offline tests; `make test-emulator` runs the live-emulator suite. `--integration` flips the marker and resolves a backend (`--emulator`/cache/menu, platform-gated); the first SUITE tests boot the emulator themselves. See `tests/AGENTS.md`.
+- Tests are **pytest**, offline by default (`addopts = -m "not emulator"`). Hardware tests carry `@pytest.mark.emulator`: `make test` runs only offline tests; `make test-emulator` runs the live-emulator suite. `--integration` flips the marker and resolves a backend (`--emulator`/cache/menu, platform-gated); the `emulator` fixture boots the emulator via `restart()`. See `tests/AGENTS.md`.
 - The clash suite is one parametrized test (`tests/clash_royale/test_jobs.py`) over an ordered `SUITE` list — add a job by appending its `run_test` to `SUITE`. Shared emulator + backend resolution live in `tests/conftest.py` + `tests/_emulator_support.py`. Select with `-k`, stop at first failure with `-x`.
 - `tests/clash_royale/` needs a live emulator and **does not run in CI** (CI only builds artifacts + runs pre-commit).
 - MSI build = cx-freeze, DMG = pyinstaller; both inject the real version (see Cross-cutting rules).

--- a/pyclashbot/bot/worker.py
+++ b/pyclashbot/bot/worker.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pyclashbot.bot.states import StateHistory, StateOrder, state_tree
 from pyclashbot.emulators import EmulatorType, get_emulator_registry
+from pyclashbot.emulators.base import EmulatorNotReadyError
 from pyclashbot.interface.enums import UIField
 from pyclashbot.utils.cancellation import CancellationToken
 from pyclashbot.utils.logger import ProcessLogger, attach_worker_file_logging
@@ -46,7 +47,7 @@ class WorkerProcess(Process):
             if emulator_selection == EmulatorType.GOOGLE_PLAY:
                 print("Creating Google Play emulator")
                 gp_device_serial = jobs.get(UIField.GP_DEVICE_SERIAL.value) or None
-                return controller_class(logger=logger, device_serial=gp_device_serial)
+                emu = controller_class(logger=logger, device_serial=gp_device_serial)
 
             elif emulator_selection == EmulatorType.BLUESTACKS:
                 print("Creating BlueStacks 5 emulator")
@@ -55,7 +56,7 @@ class WorkerProcess(Process):
                 bs_mode = jobs.get("bluestacks_render_mode", default_mode)
                 render_settings = {"graphics_renderer": bs_mode}
                 bs_device_serial = jobs.get(UIField.BS_DEVICE_SERIAL.value) or None
-                return controller_class(logger=logger, render_settings=render_settings, device_serial=bs_device_serial)
+                emu = controller_class(logger=logger, render_settings=render_settings, device_serial=bs_device_serial)
 
             elif emulator_selection == EmulatorType.MEMU:
                 print("Creating MEmu emulator")
@@ -65,19 +66,29 @@ class WorkerProcess(Process):
                     logger.change_status("MEmu is not installed! Please install it to use MEmu Emulator Mode")
                     return None
                 render_mode = jobs.get("memu_render_mode", "opengl")
-                return controller_class(logger, render_mode)
+                emu = controller_class(logger, render_mode)
 
             elif emulator_selection == EmulatorType.ADB:
                 print("Creating ADB Device controller")
                 adb_serial = jobs.get(UIField.ADB_SERIAL.value) or None
-                return controller_class(logger=logger, device_serial=adb_serial)
+                emu = controller_class(logger=logger, device_serial=adb_serial)
 
+            else:
+                return None
+
+            # Construction is cheap; restart() boots the emulator and launches Clash.
+            # First-boot failure stops the bot — there is no setup retry.
+            emu.restart()
+            return emu
+
+        except EmulatorNotReadyError as e:
+            print(f"{emulator_selection} emulator is not ready: {e}")
+            logger.change_status(f"{emulator_selection} is not ready — fix it and start the bot again.")
+            return None
         except Exception as e:
             print(f"Failed to create {emulator_selection} emulator: {e}")
             logger.change_status(f"Failed to start {emulator_selection}. Verify its installation!")
             return None
-
-        return None
 
     def _run_bot_loop(self, emulator, jobs: dict[str, Any], logger: ProcessLogger) -> None:
         """Run the main bot state loop."""

--- a/pyclashbot/emulators/AGENTS.md
+++ b/pyclashbot/emulators/AGENTS.md
@@ -6,7 +6,7 @@
 
 - Subclass `AdbBasedController` if ADB-based — then you only implement `adb(command, binary_output)` and `_check_app_installed(package)`; everything else is inherited (including `is_app_installed`, `start_app`, and the default `is_reachable()`). `start_app` raises `EmulatorNotReadyError` if the app isn't installed — there is no install-wait prompt; the bot fails fast. Otherwise subclass `BaseEmulatorController` and implement all abstract methods, including `is_app_installed(package) -> bool`.
 - `is_reachable() -> (ok, reason)` defaults to "a screenshot decodes to a non-empty array"; override it only if the backend exposes a truer liveness signal (MEmu checks VM running-state).
-- Take `logger` as the first `__init__` arg; set `supported_platforms`. `restart()` must leave Clash Royale on a main menu detectable by `check_if_on_clash_main_menu(self)`, else return `False` to trigger the retry loop.
+- Take `logger` as the first `__init__` arg; set `supported_platforms`. `__init__` does only cheap, side-effect-light discovery/config (paths, serials, config reads, VM/instance discovery+creation) — it does **not** boot. `restart()` is the boot primitive (stop → configure-while-stopped → start → launch Clash → reach main menu); it's called explicitly after construction, must leave Clash Royale on a main menu detectable by `check_if_on_clash_main_menu(self)`, and must `raise EmulatorNotReadyError` (never return `False`) on any not-ready failure.
 
 ## Gotchas
 

--- a/pyclashbot/emulators/adb.py
+++ b/pyclashbot/emulators/adb.py
@@ -4,7 +4,7 @@ import time
 
 from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.adb_base import AdbBasedController, validate_device_serial
-from pyclashbot.emulators.base import CLASH_ROYALE_PACKAGE
+from pyclashbot.emulators.base import CLASH_ROYALE_PACKAGE, EmulatorNotReadyError
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform
 
@@ -56,12 +56,9 @@ class AdbController(AdbBasedController):
 
         self.logger.log(f"Successfully connected to {self.device_serial}.")
 
-        # automatically handle screen size and density
+        # Screen size/density is idempotent and a physical device has no boot phase,
+        # so this stays in construction (documented exception). restart() launches Clash.
         self.handle_screen_size_and_density()
-
-        # In the context of a real device, the initial 'restart' is just to get the app running
-        if not self.restart():
-            raise RuntimeError("Initial restart of Clash Royale failed on the physical device.")
 
     def get_screen_props(self):
         """Gets the current screen size and density of the device."""
@@ -314,12 +311,9 @@ class AdbController(AdbBasedController):
         interruptible_sleep(3)
 
         # 2. Start the app using the inherited method
+        # start_app raises EmulatorNotReadyError if Clash Royale isn't installed.
         self.logger.change_status("Launching Clash Royale...")
-        if not self.start_app(clash_pkg):
-            # This means the app isn't installed and the user is being prompted.
-            # We can't proceed with the restart.
-            self.logger.log("App not installed. Restart cannot complete.")
-            return False
+        self.start_app(clash_pkg)
 
         interruptible_sleep(5)  # Give the app some time to load initially
 
@@ -338,4 +332,4 @@ class AdbController(AdbBasedController):
             interruptible_sleep(2)
 
         self.logger.change_status("Timeout waiting for Clash Royale main menu. Please check the device.")
-        return False
+        raise EmulatorNotReadyError("ADB device restart() timed out waiting for the Clash Royale main menu")

--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -10,7 +10,7 @@ from os.path import normpath
 
 from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.adb_base import AdbBasedController
-from pyclashbot.emulators.base import CLASH_ROYALE_PACKAGE, EmulatorNotReadyError, is_noninteractive
+from pyclashbot.emulators.base import CLASH_ROYALE_PACKAGE, EmulatorNotReadyError
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform, is_macos
 
@@ -58,12 +58,6 @@ class BlueStacksEmulatorController(AdbBasedController):
 
         self.render_settings = render_settings or {}
 
-        # Clean up our target instance only
-        self.stop()
-        while self._is_this_instance_running():  # Because Windows: I'm closing, also Windows: isn't closing
-            self.stop()
-            interruptible_sleep(1)
-
         # Discover install
         install_base = self._find_install_location()
         self.base_folder = install_base
@@ -96,26 +90,16 @@ class BlueStacksEmulatorController(AdbBasedController):
             print(f"[Bluestacks 5] bs_conf_path: {self.bs_conf_path}")
             print(f"[Bluestacks 5] mim_meta_path: {self.mim_meta_path}")
 
-        # Resolve instance and its ADB port
+        # Resolve instance and its ADB port (discovery only — restart() does the booting)
         self._ensure_managed_instance()
         if not self.instance_port:
-            raise RuntimeError("No ADB port found for the target instance in bluestacks.conf.")
+            raise EmulatorNotReadyError("No ADB port found for the target instance in bluestacks.conf.")
 
         if self._user_device_serial:
             self.device_serial: str = self._user_device_serial
             self.logger.log(f"[BlueStacks 5] Using user-specified device: {self.device_serial}")
         else:
             self.device_serial: str = f"127.0.0.1:{self.instance_port}"
-
-        # Reset our private adb server
-        self._reset_adb_server()
-
-        # Boot flow
-        while self.restart() is False:
-            if is_noninteractive():
-                raise EmulatorNotReadyError("restart() could not reach the Clash Royale main menu")
-            print("[BlueStacks 5] Restart failed, retrying...")
-            interruptible_sleep(2)
 
     @staticmethod
     def _find_install_location() -> str:
@@ -610,8 +594,19 @@ class BlueStacksEmulatorController(AdbBasedController):
         start_ts = time.time()
         self.logger.change_status("Starting BlueStacks 5 emulator restart process...")
 
+        # Clean up our target instance only (Windows can be slow to actually close)
         self.logger.change_status("Stopping pyclashbot BlueStacks 5 instance...")
         self.stop()
+        stop_deadline = time.time() + 60
+        while self._is_this_instance_running():
+            if time.time() > stop_deadline:
+                self.logger.change_status("Timeout waiting for the pyclashbot instance to stop")
+                raise EmulatorNotReadyError("BlueStacks 5 restart() timed out waiting for the instance to stop")
+            self.stop()
+            interruptible_sleep(1)
+
+        # Reset our private adb server before launching
+        self._reset_adb_server()
 
         self.logger.change_status(f"Launching BlueStacks 5 ({self.instance_name})...")
         self.start()
@@ -621,40 +616,29 @@ class BlueStacksEmulatorController(AdbBasedController):
         t0 = time.time()
         while not self._is_this_instance_running():
             if time.time() - t0 > boot_timeout:
-                self.logger.change_status("Timeout waiting for pyclashbot instance to start - retrying...")
-                return False
+                self.logger.change_status("Timeout waiting for the pyclashbot instance to start")
+                raise EmulatorNotReadyError("BlueStacks 5 restart() timed out waiting for the instance to start")
             interruptible_sleep(0.5)
 
         # Refresh port after boot
         self._refresh_instance_port()
         if not self.device_serial:
             self.logger.change_status("No ADB port resolved for this instance.")
-            return False
+            raise EmulatorNotReadyError("BlueStacks 5 restart() could not resolve an ADB port for the instance")
 
         # Connect ADB scoped to our device
         self.logger.change_status(f"Connecting ADB to {self.device_serial} ...")
         t1 = time.time()
         while not self._connect():
             if time.time() - t1 > 60:
-                self.logger.change_status("Failed to connect ADB to BlueStacks 5 - retrying...")
-                return False  # if this makes issues big problems
+                self.logger.change_status("Failed to connect ADB to BlueStacks 5")
+                raise EmulatorNotReadyError("BlueStacks 5 restart() could not connect ADB to the instance")
             interruptible_sleep(1)
 
-        # Launch Clash Royale
+        # Launch Clash Royale (start_app raises EmulatorNotReadyError if it isn't installed)
         clash_pkg = CLASH_ROYALE_PACKAGE
         self.logger.change_status("Launching Clash Royale...")
-
-        # Use inherited start_app which handles installation check
-        if not self.start_app(clash_pkg):
-            # This means app is not installed and user is being prompted.
-            # We must wait for the installation loop (handled by base class) to finish
-            # The base class's _wait_for_clash_installation will block until
-            # the user clicks 'Retry' and the app is found.
-            self.logger.log("Waiting for app installation...")
-
-            # After _wait_for_clash_installation returns True, we need to manually
-            # re-trigger the app start, because the original call failed.
-            self.start_app(clash_pkg)
+        self.start_app(clash_pkg)
 
         interruptible_sleep(5)
 
@@ -669,8 +653,8 @@ class BlueStacksEmulatorController(AdbBasedController):
                 return True
             self.click(35, 405)  # Use inherited click
 
-        self.logger.change_status("Timeout waiting for Clash Royale main menu — retrying...")
-        return False
+        self.logger.change_status("Timeout waiting for Clash Royale main menu")
+        raise EmulatorNotReadyError("BlueStacks 5 restart() timed out waiting for the Clash Royale main menu")
 
 
 if __name__ == "__main__":

--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -9,7 +9,7 @@ import psutil
 
 from pyclashbot.bot.state_detect import check_if_on_clash_main_menu
 from pyclashbot.emulators.adb_base import AdbBasedController
-from pyclashbot.emulators.base import CLASH_ROYALE_PACKAGE, EmulatorNotReadyError, is_noninteractive
+from pyclashbot.emulators.base import CLASH_ROYALE_PACKAGE, EmulatorNotReadyError
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform
 
@@ -32,12 +32,10 @@ class GooglePlayEmulatorController(AdbBasedController):
         except Exception:
             return None
 
-    def __init__(self, logger, render_settings: dict = {}, device_serial: str | None = None):
+    def __init__(self, logger, render_settings: dict | None = None, device_serial: str | None = None):
         self.logger = logger
-        # clear existing stuff
-        self.stop()
-        while self._is_emulator_running():
-            self.stop()
+        # Discovery/config only — no boot. restart() owns the boot sequence.
+        self.render_settings = render_settings or {}
 
         # search for base installation folder
         self.base_folder = self._find_install_location()
@@ -73,21 +71,9 @@ class GooglePlayEmulatorController(AdbBasedController):
         if DEBUG:
             print(f"[INIT DEBUG] Device serial set to: {self.device_serial}")
 
-        # configure the emulator via file
-        self._configure_settings(render_settings)
-
         # emulator config
         self.google_play_emulator_process_name = "Google Play Games on PC Emulator"
         self.expected_dims = (419, 633)
-
-        # boot the emulator
-        # self.restart()
-
-        while self.restart() is False:
-            if is_noninteractive():
-                raise EmulatorNotReadyError("restart() could not reach the Clash Royale main menu")
-            print("Restart failed, trying again...")
-            interruptible_sleep(2)
 
     def _get_settings_configuration(self):
         """
@@ -354,20 +340,26 @@ class GooglePlayEmulatorController(AdbBasedController):
         while self._is_emulator_running():
             self.stop()
 
+        # write render settings to the XML config while the emulator is stopped
+        self._configure_settings(self.render_settings)
+
         # boot emulator
         self.logger.change_status("Starting Google Play emulator...")
         print("Starting emulator...")
+        boot_deadline = time.time() + 120
         while not self._is_emulator_running():
+            if time.time() > boot_deadline:
+                self.logger.change_status("Timed out waiting for the Google Play emulator process to start.")
+                raise EmulatorNotReadyError("Google Play restart() timed out waiting for the emulator to start")
             self.start()
             print("Waiting for google play emulator to start...")
-            self.start()
             interruptible_sleep(0.3)
 
         # wait for adb readiness (locale-agnostic) once the VM process is up
         self.logger.change_status("Waiting for Google Play emulator to finish starting...")
         if not self._wait_for_adb_ready(timeout=120):
             self.logger.change_status("Timed out waiting for Google Play emulator ADB to become ready.")
-            return False
+            raise EmulatorNotReadyError("Google Play restart() timed out waiting for ADB to become ready")
 
         # Allow emulator services/UI to settle before manipulating display or launching the app.
         interruptible_sleep(5)
@@ -386,7 +378,7 @@ class GooglePlayEmulatorController(AdbBasedController):
                 f"[!] Fatal error: Emulator screen size is not {self.expected_dims}. "
                 "Please check the emulator settings."
             )
-            return False
+            raise EmulatorNotReadyError(f"Google Play restart() could not set screen size to {self.expected_dims}")
 
         # boot clash
         self.logger.change_status("Launching Clash Royale application...")
@@ -396,10 +388,8 @@ class GooglePlayEmulatorController(AdbBasedController):
         for i in range(start_app_count):
             self.logger.change_status(f"Starting Clash Royale (attempt {i + 1}/{start_app_count})...")
             print(f"Starting clash app (attempt {i + 1}/{start_app_count})...")
-            if not self.start_app(clash_royale_name) and i == 0:
-                # App not installed, start_app triggered the wait.
-                # We just wait for it to return, then the loop will retry.
-                self.logger.log("App not installed. Waiting for user...")
+            # start_app raises EmulatorNotReadyError if Clash Royale isn't installed
+            self.start_app(clash_royale_name)
             interruptible_sleep(1)
 
         # wait for clash main to appear
@@ -410,12 +400,9 @@ class GooglePlayEmulatorController(AdbBasedController):
         interruptible_sleep(12)
         while 1:
             if time.time() - clash_main_wait_start_time > clash_main_wait_timeout:
-                self.logger.change_status("Timeout waiting for Clash Royale main menu - restarting...")
+                self.logger.change_status("Timeout waiting for Clash Royale main menu")
                 self.logger.log("[!] Fatal error: Timeout reached while waiting for clash main menu to appear.")
-                # TODO(noninteractive): see is_noninteractive() in base.py for the removal plan.
-                if is_noninteractive():
-                    raise EmulatorNotReadyError("restart() timed out waiting for the Clash Royale main menu")
-                return self.restart()
+                raise EmulatorNotReadyError("Google Play restart() timed out waiting for the Clash Royale main menu")
 
             # if found main in time, break
             if check_if_on_clash_main_menu(self) is True:

--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -19,7 +19,6 @@ from pyclashbot.emulators.base import (
     CLASH_ROYALE_PACKAGE,
     BaseEmulatorController,
     EmulatorNotReadyError,
-    is_noninteractive,
 )
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import Platform
@@ -168,32 +167,26 @@ class MemuEmulatorController(BaseEmulatorController):
         self.logger.log("Need to clear residual memu processes here")
 
     def _initialize_valid_vm(self):
-        # no timeout here bc if this fails, then something fatal is wrong
+        # Side-effect-light discovery: find-or-create the VM so self.vm_index is
+        # known. No configure/boot here — restart() owns the boot sequence.
         self.logger.log("Initializing MEmu VM...")
-        vm_index = -1
-        while 1:
-            # check for a valid vm
-            self.logger.log("Checking for an existing valid vm...")
-            vm_index = self._get_clashbot_vm_index()
-            if vm_index is not False:
-                self.logger.log(f"[+] Found {EMULATOR_NAME} VM: {vm_index}")
-                self.vm_index = vm_index
-                break
 
-            # if none found, create a new one
-            self.logger.log(f"No existing {EMULATOR_NAME} (Android 13) VM found, creating one...")
-            vm_index = self.create()
-            if vm_index != -1:
-                self._rename_vm(EMULATOR_NAME)
-                self.logger.log(f"[+] Created a new vm: {vm_index}")
-                break
+        # check for a valid vm
+        self.logger.log("Checking for an existing valid vm...")
+        vm_index = self._get_clashbot_vm_index()
+        if vm_index is not False:
+            self.logger.log(f"[+] Found {EMULATOR_NAME} VM: {vm_index}")
+            self.vm_index = vm_index
+            return
 
+        # if none found, create one (a single attempt — no infinite loop)
+        self.logger.log(f"No existing {EMULATOR_NAME} (Android 13) VM found, creating one...")
+        vm_index = self.create()
+        if vm_index == -1:
+            raise EmulatorNotReadyError(f"Failed to create a {EMULATOR_NAME} MEmu VM")
+        self._rename_vm(EMULATOR_NAME)
+        self.logger.log(f"[+] Created a new vm: {vm_index}")
         self.vm_index = vm_index
-
-        self.logger.log("Configuring the vm...")
-        self.configure()
-        self.logger.log("Booting the vm...")
-        self.restart()
 
     def _set_screen_size(self, width, height):
         self.pmc.send_adb_command_vm(
@@ -1025,15 +1018,11 @@ class MemuEmulatorController(BaseEmulatorController):
 
         return True
 
-    def restart(self, open_clash=True, start_time=None):
+    def restart(self) -> bool:
         """Restart the emulator with full configuration and app startup sequence.
 
-        Args:
-            open_clash (bool): Whether to start Clash Royale after emulator boot
-            start_time (float): Start time for timing calculations
-
-        Returns:
-            bool: True if restart successful, False otherwise
+        Returns True once Clash Royale is on the main menu; raises
+        EmulatorNotReadyError on any not-ready failure (never returns False).
         """
         debug_restart = DEBUG_CONFIGURATION.get("restart", False)
         debug_vm_ops = DEBUG_CONFIGURATION.get("vm_operations", False)
@@ -1043,20 +1032,12 @@ class MemuEmulatorController(BaseEmulatorController):
             self.logger.log("[RESTART] =====================================================")
             self.logger.log("[RESTART] INITIALIZING RESTART METHOD")
             self.logger.log("[RESTART] =====================================================")
-            self.logger.log("[RESTART] Method parameters:")
-            self.logger.log(f"[RESTART]   open_clash: {open_clash} (type: {type(open_clash)})")
-            self.logger.log(f"[RESTART]   start_time: {start_time} (type: {type(start_time)})")
             self.logger.log("[RESTART] Debug flags active:")
             self.logger.log(f"[RESTART]   debug_restart: {debug_restart}")
             self.logger.log(f"[RESTART]   debug_vm_ops: {debug_vm_ops}")
             self.logger.log(f"[RESTART]   debug_clash: {debug_clash}")
 
-        if start_time is None:
-            start_time = time.time()
-            if debug_restart:
-                self.logger.log(f"[RESTART] start_time was None, set to current time: {start_time}")
-        elif debug_restart:
-            self.logger.log(f"[RESTART] Using provided start_time: {start_time}")
+        start_time = time.time()
 
         # Validate vm_index with extreme verbosity
         if debug_restart:
@@ -1074,9 +1055,7 @@ class MemuEmulatorController(BaseEmulatorController):
             error_msg = "[!] Fatal error: No valid vm_index in MemuEmulatorController.restart()"
             self.logger.change_status(error_msg)
             self.logger.log(error_msg)
-            if debug_restart:
-                self.logger.log("[RESTART] VM INDEX VALIDATION FAILED - RETURNING FALSE")
-            return False
+            raise EmulatorNotReadyError("MEmu restart() has no valid vm_index")
 
         if debug_restart:
             self.logger.log("[RESTART] ✓ VM INDEX VALIDATION PASSED")
@@ -1089,7 +1068,6 @@ class MemuEmulatorController(BaseEmulatorController):
             self.logger.log("[RESTART] Restart sequence parameters:")
             self.logger.log(f"[RESTART]   VM Index: {self.vm_index}")
             self.logger.log(f"[RESTART]   Render Mode: {self.render_mode}")
-            self.logger.log(f"[RESTART]   Open Clash: {open_clash}")
             self.logger.log(f"[RESTART]   Start Time: {start_time}")
             self.logger.log(f"[RESTART]   Current Time: {time.time()}")
 
@@ -1176,10 +1154,10 @@ class MemuEmulatorController(BaseEmulatorController):
                 self.logger.log(f"[RESTART] Exception type: {type(e)}")
                 self.logger.log(f"[RESTART] Exception message: {e}")
                 self.logger.log(f"[RESTART] VM start attempt duration: {vm_start_end - vm_start_time:.3f}s")
-                self.logger.log("[RESTART] RETURNING FALSE DUE TO VM START FAILURE")
+                self.logger.log("[RESTART] RAISING DUE TO VM START FAILURE")
 
             self.logger.change_status(error_msg)
-            return False
+            raise EmulatorNotReadyError(f"MEmu restart() failed to start the VM: {e}") from e
 
         # Step 4: Skip ads with extreme verbosity
         if debug_restart or DEBUG_CONFIGURATION.get("ads", False):
@@ -1202,14 +1180,10 @@ class MemuEmulatorController(BaseEmulatorController):
 
         if not ads_result:
             if debug_restart:
-                self.logger.log("[RESTART] ✗ AD SKIP FAILED - INITIATING RECURSIVE RESTART")
-                self.logger.log(f"[RESTART] Calling self.restart(open_clash={open_clash}, start_time={start_time})")
+                self.logger.log("[RESTART] ✗ AD SKIP FAILED")
 
-            self.logger.change_status("Failed to skip ads, restarting...")
-            # TODO(noninteractive): see is_noninteractive() in base.py for the removal plan.
-            if is_noninteractive():
-                raise EmulatorNotReadyError("restart() failed to skip MEmu ads")
-            return self.restart(open_clash=open_clash, start_time=start_time)
+            self.logger.change_status("Failed to skip MEmu ads")
+            raise EmulatorNotReadyError("MEmu restart() failed to skip the startup ads")
 
         if debug_restart:
             self.logger.log("[RESTART] ✓ SUCCESSFULLY SKIPPED ADS")
@@ -1235,166 +1209,137 @@ class MemuEmulatorController(BaseEmulatorController):
 
         if not size_valid:
             if debug_restart:
-                self.logger.log("[RESTART] ✗ SCREEN SIZE VALIDATION FAILED - INITIATING RECURSIVE RESTART")
-                self.logger.log(f"[RESTART] Calling self.restart(open_clash={open_clash}, start_time={start_time})")
+                self.logger.log("[RESTART] ✗ SCREEN SIZE VALIDATION FAILED")
 
-            self.logger.change_status("VM size validation failed, restarting...")
-            # TODO(noninteractive): see is_noninteractive() in base.py for the removal plan.
-            if is_noninteractive():
-                raise EmulatorNotReadyError("restart() failed VM screen-size validation")
-            return self.restart(open_clash=open_clash, start_time=start_time)
+            self.logger.change_status("VM size validation failed")
+            raise EmulatorNotReadyError("MEmu restart() failed VM screen-size validation")
 
         if debug_restart:
             self.logger.log("[RESTART] ✓ SCREEN SIZE VALIDATION PASSED")
 
-        # Step 6: Start Clash Royale if requested with extreme verbosity
-        if open_clash:
-            if debug_restart or debug_clash:
-                self.logger.log("[RESTART] =====================================================")
-                self.logger.log("[RESTART] STEP 6: STARTING CLASH ROYALE")
-                self.logger.log("[RESTART] =====================================================")
-                self.logger.log("[RESTART] open_clash is True, proceeding with Clash Royale startup")
+        # Step 6: Start Clash Royale
+        if debug_restart or debug_clash:
+            self.logger.log("[RESTART] =====================================================")
+            self.logger.log("[RESTART] STEP 6: STARTING CLASH ROYALE")
+            self.logger.log("[RESTART] =====================================================")
 
-            self.logger.change_status("Starting Clash Royale...")
-            if debug_restart:
-                self.logger.log("[RESTART] Logger status updated to: 'Starting Clash Royale...'")
-                self.logger.log(f"[RESTART] About to call self.start_app({CLASH_ROYALE_PACKAGE!r})")
+        self.logger.change_status("Starting Clash Royale...")
+        if debug_restart:
+            self.logger.log("[RESTART] Logger status updated to: 'Starting Clash Royale...'")
+            self.logger.log(f"[RESTART] About to call self.start_app({CLASH_ROYALE_PACKAGE!r})")
 
-            clash_start_time = time.time()
-            try:
-                app_start_result = self.start_app(CLASH_ROYALE_PACKAGE)
-                clash_start_end = time.time()
-
-                if debug_clash:
-                    self.logger.log(f"[RESTART] self.start_app() returned: {app_start_result}")
-                    self.logger.log(f"[RESTART] Clash start duration: {clash_start_end - clash_start_time:.3f}s")
-
-                if not app_start_result:
-                    if debug_restart:
-                        self.logger.log("[RESTART] ✗ CLASH ROYALE START FAILED")
-                        self.logger.log("[RESTART] RETURNING FALSE DUE TO CLASH START FAILURE")
-                    return False
-
-                if debug_restart:
-                    self.logger.log("[RESTART] ✓ CLASH ROYALE STARTED SUCCESSFULLY")
-
-            except Exception as e:
-                clash_start_end = time.time()
-                if debug_restart:
-                    self.logger.log("[RESTART] ✗ EXCEPTION DURING CLASH ROYALE START")
-                    self.logger.log(f"[RESTART] Exception type: {type(e)}")
-                    self.logger.log(f"[RESTART] Exception message: {e}")
-                    self.logger.log(
-                        f"[RESTART] Clash start attempt duration: {clash_start_end - clash_start_time:.3f}s"
-                    )
-                return False
-
-            # Step 7: Wait for Clash main menu with extreme verbosity
-            if debug_restart or debug_clash:
-                self.logger.log("[RESTART] =====================================================")
-                self.logger.log("[RESTART] STEP 7: WAITING FOR CLASH ROYALE MAIN MENU")
-                self.logger.log("[RESTART] =====================================================")
-
-            self.logger.change_status("Waiting for Clash Royale main menu...")
-            if debug_restart:
-                self.logger.log("[RESTART] Logger status updated to: 'Waiting for Clash Royale main menu...'")
-
-            clash_main_wait_start_time = time.time()
-            clash_main_wait_timeout = 240  # seconds
+        clash_start_time = time.time()
+        try:
+            # start_app raises EmulatorNotReadyError if Clash Royale isn't installed
+            self.start_app(CLASH_ROYALE_PACKAGE)
+            clash_start_end = time.time()
 
             if debug_clash:
-                self.logger.log("[RESTART] Wait parameters:")
-                self.logger.log(f"[RESTART]   wait_start_time: {clash_main_wait_start_time}")
-                self.logger.log(f"[RESTART]   wait_timeout: {clash_main_wait_timeout}s")
-                self.logger.log(f"[RESTART]   wait_end_time: {clash_main_wait_start_time + clash_main_wait_timeout}")
-                self.logger.log("[RESTART] Initial 12-second wait before checking main menu...")
+                self.logger.log(f"[RESTART] Clash start duration: {clash_start_end - clash_start_time:.3f}s")
 
-            interruptible_sleep(12)  # Initial wait
+            if debug_restart:
+                self.logger.log("[RESTART] ✓ CLASH ROYALE STARTED SUCCESSFULLY")
+
+        except EmulatorNotReadyError:
+            raise
+        except Exception as e:
+            clash_start_end = time.time()
+            if debug_restart:
+                self.logger.log("[RESTART] ✗ EXCEPTION DURING CLASH ROYALE START")
+                self.logger.log(f"[RESTART] Exception type: {type(e)}")
+                self.logger.log(f"[RESTART] Exception message: {e}")
+                self.logger.log(f"[RESTART] Clash start attempt duration: {clash_start_end - clash_start_time:.3f}s")
+            raise EmulatorNotReadyError(f"MEmu restart() failed to start Clash Royale: {e}") from e
+
+        # Step 7: Wait for Clash main menu with extreme verbosity
+        if debug_restart or debug_clash:
+            self.logger.log("[RESTART] =====================================================")
+            self.logger.log("[RESTART] STEP 7: WAITING FOR CLASH ROYALE MAIN MENU")
+            self.logger.log("[RESTART] =====================================================")
+
+        self.logger.change_status("Waiting for Clash Royale main menu...")
+        if debug_restart:
+            self.logger.log("[RESTART] Logger status updated to: 'Waiting for Clash Royale main menu...'")
+
+        clash_main_wait_start_time = time.time()
+        clash_main_wait_timeout = 240  # seconds
+
+        if debug_clash:
+            self.logger.log("[RESTART] Wait parameters:")
+            self.logger.log(f"[RESTART]   wait_start_time: {clash_main_wait_start_time}")
+            self.logger.log(f"[RESTART]   wait_timeout: {clash_main_wait_timeout}s")
+            self.logger.log(f"[RESTART]   wait_end_time: {clash_main_wait_start_time + clash_main_wait_timeout}")
+            self.logger.log("[RESTART] Initial 12-second wait before checking main menu...")
+
+        interruptible_sleep(12)  # Initial wait
+
+        if debug_clash:
+            self.logger.log("[RESTART] Initial wait complete, starting main menu detection loop...")
+
+        loop_iteration = 0
+        while time.time() - clash_main_wait_start_time < clash_main_wait_timeout:
+            loop_iteration += 1
+            current_time = time.time()
+            elapsed_wait = current_time - clash_main_wait_start_time
+            remaining_time = clash_main_wait_timeout - elapsed_wait
 
             if debug_clash:
-                self.logger.log("[RESTART] Initial wait complete, starting main menu detection loop...")
+                self.logger.log(f"[RESTART] Main menu wait loop iteration {loop_iteration}")
+                self.logger.log(f"[RESTART]   Current time: {current_time}")
+                self.logger.log(f"[RESTART]   Elapsed wait: {elapsed_wait:.1f}s")
+                self.logger.log(f"[RESTART]   Remaining time: {remaining_time:.1f}s")
+                self.logger.log("[RESTART] Checking if on Clash main menu...")
 
-            loop_iteration = 0
-            while time.time() - clash_main_wait_start_time < clash_main_wait_timeout:
-                loop_iteration += 1
-                current_time = time.time()
-                elapsed_wait = current_time - clash_main_wait_start_time
-                remaining_time = clash_main_wait_timeout - elapsed_wait
-
-                if debug_clash:
-                    self.logger.log(f"[RESTART] Main menu wait loop iteration {loop_iteration}")
-                    self.logger.log(f"[RESTART]   Current time: {current_time}")
-                    self.logger.log(f"[RESTART]   Elapsed wait: {elapsed_wait:.1f}s")
-                    self.logger.log(f"[RESTART]   Remaining time: {remaining_time:.1f}s")
-                    self.logger.log("[RESTART] Checking if on Clash main menu...")
-
-                menu_check_start = time.time()
-                if check_if_on_clash_main_menu(self):
-                    menu_check_end = time.time()
-                    total_elapsed = str(time.time() - start_time)[:5]
-
-                    if debug_clash:
-                        self.logger.log("[RESTART] ✓ CLASH MAIN MENU DETECTED!")
-                        self.logger.log(f"[RESTART] Menu check duration: {menu_check_end - menu_check_start:.3f}s")
-                        self.logger.log(f"[RESTART] Total wait time: {elapsed_wait:.1f}s")
-                        self.logger.log(f"[RESTART] Total restart time: {total_elapsed}s")
-
-                    self.logger.change_status("Clash Royale main menu detected")
-                    self.logger.log(f"Emulator restart completed in {total_elapsed}s")
-
-                    if debug_restart:
-                        self.logger.log("[RESTART] =====================================================")
-                        self.logger.log("[RESTART] RESTART SEQUENCE COMPLETED SUCCESSFULLY")
-                        self.logger.log("[RESTART] =====================================================")
-
-                    return True
-
+            menu_check_start = time.time()
+            if check_if_on_clash_main_menu(self):
                 menu_check_end = time.time()
-                if debug_clash:
-                    self.logger.log(
-                        f"[RESTART] Main menu not detected (check took {menu_check_end - menu_check_start:.3f}s)"
-                    )
-                    self.logger.log("[RESTART] Clicking deadspace at (5, 350) to handle popups...")
-
-                # Click deadspace to handle any popups
-                click_start = time.time()
-                self.click(35, 405)
-                click_end = time.time()
+                total_elapsed = str(time.time() - start_time)[:5]
 
                 if debug_clash:
-                    self.logger.log(f"[RESTART] Deadspace click completed ({click_end - click_start:.3f}s)")
-                    self.logger.log("[RESTART] Sleeping for 1 second before next iteration...")
+                    self.logger.log("[RESTART] ✓ CLASH MAIN MENU DETECTED!")
+                    self.logger.log(f"[RESTART] Menu check duration: {menu_check_end - menu_check_start:.3f}s")
+                    self.logger.log(f"[RESTART] Total wait time: {elapsed_wait:.1f}s")
+                    self.logger.log(f"[RESTART] Total restart time: {total_elapsed}s")
 
-                interruptible_sleep(1)
+                self.logger.change_status("Clash Royale main menu detected")
+                self.logger.log(f"Emulator restart completed in {total_elapsed}s")
 
-            # Timeout waiting for main menu
-            final_elapsed_wait = time.time() - clash_main_wait_start_time
-            if debug_restart or debug_clash:
-                self.logger.log("[RESTART] ✗ TIMEOUT WAITING FOR CLASH MAIN MENU")
-                self.logger.log(f"[RESTART] Total wait time: {final_elapsed_wait:.1f}s")
-                self.logger.log(f"[RESTART] Timeout threshold: {clash_main_wait_timeout}s")
-                self.logger.log(f"[RESTART] Loop iterations: {loop_iteration}")
-                self.logger.log("[RESTART] INITIATING RECURSIVE RESTART DUE TO TIMEOUT")
+                if debug_restart:
+                    self.logger.log("[RESTART] =====================================================")
+                    self.logger.log("[RESTART] RESTART SEQUENCE COMPLETED SUCCESSFULLY")
+                    self.logger.log("[RESTART] =====================================================")
 
-            self.logger.change_status("Timeout waiting for Clash Royale main menu — restarting...")
-            # TODO(noninteractive): see is_noninteractive() in base.py for the removal plan.
-            if is_noninteractive():
-                raise EmulatorNotReadyError("restart() timed out waiting for the Clash Royale main menu")
-            return self.restart(open_clash=open_clash, start_time=start_time)
+                return True
 
-        # If not opening Clash, we're done
-        else:
-            total_elapsed = str(time.time() - start_time)[:5]
+            menu_check_end = time.time()
+            if debug_clash:
+                self.logger.log(
+                    f"[RESTART] Main menu not detected (check took {menu_check_end - menu_check_start:.3f}s)"
+                )
+                self.logger.log("[RESTART] Clicking deadspace at (5, 350) to handle popups...")
 
-            if debug_restart:
-                self.logger.log("[RESTART] =====================================================")
-                self.logger.log("[RESTART] RESTART SEQUENCE COMPLETED (NO CLASH)")
-                self.logger.log("[RESTART] =====================================================")
-                self.logger.log("[RESTART] open_clash was False, skipping Clash Royale startup")
-                self.logger.log(f"[RESTART] Total restart time: {total_elapsed}s")
+            # Click deadspace to handle any popups
+            click_start = time.time()
+            self.click(35, 405)
+            click_end = time.time()
 
-            self.logger.log(f"Emulator restart completed in {total_elapsed}s")
-            return True
+            if debug_clash:
+                self.logger.log(f"[RESTART] Deadspace click completed ({click_end - click_start:.3f}s)")
+                self.logger.log("[RESTART] Sleeping for 1 second before next iteration...")
+
+            interruptible_sleep(1)
+
+        # Timeout waiting for main menu
+        final_elapsed_wait = time.time() - clash_main_wait_start_time
+        if debug_restart or debug_clash:
+            self.logger.log("[RESTART] ✗ TIMEOUT WAITING FOR CLASH MAIN MENU")
+            self.logger.log(f"[RESTART] Total wait time: {final_elapsed_wait:.1f}s")
+            self.logger.log(f"[RESTART] Timeout threshold: {clash_main_wait_timeout}s")
+            self.logger.log(f"[RESTART] Loop iterations: {loop_iteration}")
+            self.logger.log("[RESTART] RAISING DUE TO MAIN-MENU TIMEOUT")
+
+        self.logger.change_status("Timeout waiting for Clash Royale main menu")
+        raise EmulatorNotReadyError("MEmu restart() timed out waiting for the Clash Royale main menu")
 
     def start(self):
         self.pmc.start_vm(vm_index=self.vm_index)
@@ -1517,6 +1462,7 @@ if __name__ == "__main__":
 
     test_logger = Logger()
     memu = MemuEmulatorController(test_logger, render_mode="directx")
+    memu.restart()  # construction is cheap now; restart() boots the VM + launches Clash
     while 1:
         test_logger.log("Running")
         interruptible_sleep(10)

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -12,9 +12,9 @@ and resolves a backend.
   committed fixtures, no emulator (e.g. `test_card_fingerprint_bgr.py`,
   `test_emulator_resolution.py`).
 - `clash_royale/` — live end-to-end suite: one parametrized test
-  (`test_jobs.py`) over the ordered `SUITE`. The emulator is booted in fixture
-  construction; the first two entries are setup (app-installed check, screenshot
-  smoke) and the rest are jobs. See `clash_royale/readme.md`.
+  (`test_jobs.py`) over the ordered `SUITE`. The emulator is booted by `restart()`
+  in the fixture (via `attach_emulator`); the first two entries are setup
+  (app-installed check, screenshot smoke) and the rest are jobs. See `clash_royale/readme.md`.
 - `_emulator_support.py` — not a test module: backend resolution and
   `attach_emulator()` behind the `emulator` fixture (cross-run persistence is
   pytest's `config.cache`, wired in `conftest.py`).
@@ -36,12 +36,13 @@ and resolves a backend.
 
 ## Conventions
 
-- The session-scoped `emulator` fixture only constructs the controller; it
-  `pytest.exit`s the whole run if construction fails. Construction launches Clash
-  and reaches the main menu — MEmu/BlueStacks/Google Play boot the VM, while ADB
-  attaches to an already-running device and (re)launches Clash. Either way a
+- The session-scoped `emulator` fixture attaches via `attach_emulator`, which
+  constructs the controller (cheap discovery/config) then calls `restart()` to boot
+  it; it `pytest.exit`s the whole run if either step fails. `restart()` launches
+  Clash and reaches the main menu — MEmu/BlueStacks/Google Play boot the VM, while
+  ADB attaches to an already-running device and (re)launches Clash. Either way a
   not-ready emulator (app missing, signed out, no main menu) fails fast there with
-  a clear `EmulatorNotReadyError`-based message rather than hanging on a GUI prompt
+  a clear `EmulatorNotReadyError` rather than hanging on a GUI prompt
   (`PYCLASHBOT_NONINTERACTIVE=1`, set in integration mode).
 - A clash entry is a `run_test(emulator, logger) -> (bool, str)`. Add one by
   appending its `run_test` to `SUITE` in `test_jobs.py`; entries run with `-x` and

--- a/tests/_emulator_support.py
+++ b/tests/_emulator_support.py
@@ -96,9 +96,13 @@ def resolve_serial(cli_opt: str | None, cache: dict) -> tuple[str | None, bool]:
 
 
 def attach_emulator(cli_alias: str, logger: Logger, device_serial: str | None = None):
-    """Construct the controller for `cli_alias`; return it or None (printing why).
+    """Construct the controller for `cli_alias`, boot it via restart(), and return it
+    (or None, printing why).
 
-    Passes device_serial only when the controller's __init__ accepts it.
+    Construction is cheap discovery/config; restart() does the booting (VM start +
+    Clash launch + main-menu wait). A not-ready emulator raises EmulatorNotReadyError
+    from either step — that re-raises so the fixture can report it. Passes
+    device_serial only when the controller's __init__ accepts it.
     """
     from pyclashbot.emulators import EmulatorType, get_emulator_registry
 
@@ -129,7 +133,9 @@ def attach_emulator(cli_alias: str, logger: Logger, device_serial: str | None = 
         kwargs["device_serial"] = device_serial
 
     try:
-        return cls(logger, **kwargs)
+        emu = cls(logger, **kwargs)
+        emu.restart()
+        return emu
     except EmulatorNotReadyError:
         raise  # a real "not set up" signal — let the fixture report it, don't mask as None
     except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,8 +143,9 @@ def emulator(request: pytest.FixtureRequest, logger):
     serial = request.config.stash[_SERIAL_KEY]
 
     # Hard-abort (pytest.exit, not skip): a missing/not-ready emulator would chain
-    # false negatives across the ordered suite. Controllers boot + launch Clash in
-    # construction, so "not set up" surfaces here rather than as a per-test failure.
+    # false negatives across the ordered suite. attach_emulator constructs the
+    # controller then boots it via restart(), so "not set up" surfaces here rather
+    # than as a per-test failure.
     try:
         emu = attach_emulator(backend, logger, device_serial=serial)
     except EmulatorNotReadyError as e:

--- a/tests/test_emulator_setup_failfast.py
+++ b/tests/test_emulator_setup_failfast.py
@@ -1,0 +1,71 @@
+"""Offline coverage for the construct-then-restart() boot contract (PR2).
+
+Controllers construct cheaply and boot in restart(); a not-ready emulator raises
+EmulatorNotReadyError from restart(). These tests pin how the two construction
+sites react to that raise — without any hardware — by swapping the registry for a
+fake controller whose restart() blows up.
+"""
+
+import pytest
+
+from pyclashbot.emulators import EmulatorType
+from pyclashbot.emulators.base import EmulatorNotReadyError
+
+
+class _FakeNotReadyController:
+    """Cheap to construct; restart() raises like a not-ready emulator."""
+
+    constructed = 0
+
+    def __init__(self, logger, **kwargs):
+        type(self).constructed += 1
+        self.logger = logger
+
+    def restart(self):
+        raise EmulatorNotReadyError("fake emulator is not ready")
+
+
+class _RecordingLogger:
+    def __init__(self):
+        self.statuses: list[str] = []
+
+    def change_status(self, status):
+        self.statuses.append(status)
+
+    def log(self, *args, **kwargs):
+        pass
+
+
+def test_attach_emulator_reraises_when_restart_not_ready(monkeypatch):
+    import pyclashbot.emulators as emulators_pkg
+
+    monkeypatch.setattr(
+        emulators_pkg,
+        "get_emulator_registry",
+        lambda: {EmulatorType.ADB: _FakeNotReadyController},
+    )
+
+    from tests._emulator_support import attach_emulator
+
+    with pytest.raises(EmulatorNotReadyError):
+        attach_emulator("adb", _RecordingLogger())
+
+
+def test_setup_emulator_returns_none_and_reports_when_restart_not_ready(monkeypatch):
+    from pyclashbot.bot import worker as worker_module
+
+    monkeypatch.setattr(
+        worker_module,
+        "get_emulator_registry",
+        lambda: {EmulatorType.ADB: _FakeNotReadyController},
+    )
+
+    # _setup_emulator doesn't touch instance state; skip Process.__init__.
+    worker = worker_module.WorkerProcess.__new__(worker_module.WorkerProcess)
+    logger = _RecordingLogger()
+
+    result = worker._setup_emulator({"emulator": EmulatorType.ADB}, logger)
+
+    assert result is None
+    assert logger.statuses, "expected a user-facing status explaining the abort"
+    assert any("not ready" in status.lower() for status in logger.statuses)


### PR DESCRIPTION
**Stacked on #708 (PR1).** Review/merge #708 first. The base is PR1's branch, so this PR's diff shows only PR2's changes.

## What

Adapter lifecycle refactor: `__init__` becomes side-effect-light discovery/config only; `restart()` becomes the single boot primitive that boots **once** and `raise EmulatorNotReadyError` on any not-ready failure.

This replaces, per adapter:
- `while self.restart() is False:` boot loops in `__init__`
- recursive `return self.restart(...)` on transient failures
- not-ready `return False` exits

Both construction sites flip in the same PR (the moment `__init__` stops booting, every caller gets a non-booted controller):
- `worker._setup_emulator`: constructs, then `emu.restart()`; `EmulatorNotReadyError` → `change_status` + `return None` (bot stops, **no setup retry**).
- `tests/_emulator_support.py::attach_emulator`: constructs, then `restart()` inside the same `try`, so first-boot failure re-raises to the fixture.

Mid-run recovery is unchanged: `states.py`'s `emulator.restart()` raising propagates into `_run_bot_loop`'s existing `except` → bounded `consecutive_restarts = 5`.

## Per-adapter
- **MEmu**: `_initialize_valid_vm` keeps find-or-create (now find-once/create-once/raise, no `while 1:`); dropped `configure()`/`restart()` from construction (the stopped-VM `configure()` inside `restart()` survives). All not-ready recursion/`return False` → raise. `__main__` dev block now calls `restart()` explicitly. **Also dropped the now-vestigial `open_clash`/`start_time` params from `restart()`** (recursion remnants — the `if open_clash:` block dedented to unconditional, dead skip-`else` removed).
- **BlueStacks**: discovery + `_ensure_managed_instance` + `device_serial` stay in `__init__` (instance_port `RuntimeError` → `EmulatorNotReadyError`); stop-loop + `_reset_adb_server()` moved into `restart()` — **the relocated instance-stop loop is now deadline-bounded (raises on timeout)**, so every wait in `restart()` is bounded; `return False` → raise; install-wait collapsed to a single `start_app` (which raises from PR1).
- **Google Play**: discovery + dims stay; `render_settings` stashed on `self`; `_configure_settings` moved into `restart()` (writes XML while stopped); unbounded start loop now deadline-bounded; recursion/timeouts → raise.
- **ADB**: dropped the `__init__` boot (`handle_screen_size_and_density` stays — documented idempotent exception); `return False` → raise.

## Review fold-ins
A stacked review pass (`/review` + a comment-churn audit) produced two refinements, folded into this PR: bounding the one remaining unbounded wait (the BlueStacks instance-stop loop) and removing the vestigial `open_clash`/`start_time` params from `memu.restart()`. The memu `restart()` docstring fix (`False` → raises) that originally lived in #710 also migrated here, since this PR now owns that method's signature/contract.

## Tests
- New offline test `tests/test_emulator_setup_failfast.py`: a fake controller whose `restart()` raises asserts `attach_emulator` re-raises and `_setup_emulator` returns `None` + reports status. No hardware needed.
- `make lint` ✅, `make test` ✅ (16 passed, 15 deselected offline).

## Manual verification before merge
This is the only PR that exercises the real boot sequence, and **CI cannot run it** (`make test-emulator # --integration --emulator bluestacks`).

- [x] **Construct is cheap** — first stdout line is `restart()`'s own `Starting BlueStacks 5 emulator restart process...`; no boot work happens in `__init__`.
- [x] **`restart()` boots once and reaches the main menu** — verified live on macOS/BlueStacks: stop → launch → ADB connect (`127.0.0.1:5555`) → launch Clash → `Clash Royale main menu detected` → `BlueStacks 5 restart completed in 22.0s`. The two boot-path SUITE entries (app-installed check, screenshot smoke) passed.
- [x] **Not-ready emulator aborts fast** — verified live with Clash uninstalled: `ABORTING: bluestacks emulator is not ready: com.supercell.clashroyale is not installed on the emulator`. Fails fast at fixture setup, no hang, no "Retry" prompt. (Also covered offline by `test_emulator_setup_failfast.py`.)

> ⚠️ The bounded BlueStacks stop-loop is on a path the live macOS/BlueStacks run exercises. The memu param removal + dedent is on the **Windows-only** MEmu boot path — covered by lint/AST/offline tests but **not** by the macOS run; a smoke boot on MEmu/Windows is the only way to live-verify it.

> Note: in the live run, `nav_main_pages` failed (`navigate_main_page('main' -> 'war')`). That is a pre-existing navigation/detection issue in the live suite, **downstream of a fully-booted emulator** — not a boot regression from this PR.

## Docs
Corrected the four statements PR2 makes factually false (construct-vs-boot contract in `emulators/AGENTS.md`, `tests/AGENTS.md`, root `AGENTS.md`, conftest fixture docstring). The `is_noninteractive` / `PYCLASHBOT_NONINTERACTIVE` scaffolding deletion is deferred to PR3.

## Follow-up
PR3 (#710) deletes the transitional `is_noninteractive()` + `PYCLASHBOT_NONINTERACTIVE` scaffolding now that adapters fail fast unconditionally, and adds an "adapters are ports — keep bot policy out" rule to `emulators/AGENTS.md`.
