### PR TITLE
refactor(emulators): delete transitional noninteractive scaffolding (PR3)

### DIFF
--- a/pyclashbot/emulators/AGENTS.md
+++ b/pyclashbot/emulators/AGENTS.md
@@ -4,6 +4,7 @@
 
 ## Adding an emulator
 
+- **Adapters are ports — keep bot policy out.** Retry counts, human prompts, give-up and mid-run-recovery decisions live in the caller (`bot/worker.py`, the test fixture), never in an adapter — so the contract stays drivable by integration tests with no GUI or env-var scaffolding.
 - Subclass `AdbBasedController` if ADB-based — then you only implement `adb(command, binary_output)` and `_check_app_installed(package)`; everything else is inherited (including `is_app_installed`, `start_app`, and the default `is_reachable()`). `start_app` raises `EmulatorNotReadyError` if the app isn't installed — there is no install-wait prompt; the bot fails fast. Otherwise subclass `BaseEmulatorController` and implement all abstract methods, including `is_app_installed(package) -> bool`.
 - `is_reachable() -> (ok, reason)` defaults to "a screenshot decodes to a non-empty array"; override it only if the backend exposes a truer liveness signal (MEmu checks VM running-state).
 - Take `logger` as the first `__init__` arg; set `supported_platforms`. `__init__` does only cheap, side-effect-light discovery/config (paths, serials, config reads, VM/instance discovery+creation) — it does **not** boot. `restart()` is the boot primitive (stop → configure-while-stopped → start → launch Clash → reach main menu); it's called explicitly after construction, must leave Clash Royale on a main menu detectable by `check_if_on_clash_main_menu(self)`, and must `raise EmulatorNotReadyError` (never return `False`) on any not-ready failure.
@@ -11,7 +12,7 @@
 ## Gotchas
 
 - The Clash Royale package id lives in `base.py` as `CLASH_ROYALE_PACKAGE` — never re-inline the `"com.supercell.clashroyale"` string.
-- A not-ready emulator (app missing, signed out, no main menu, no clean instance) must `raise EmulatorNotReadyError` (from `base.py`) — never block on a GUI "Retry" prompt; there is no human-in-the-loop prompt path. New boot/restart retry loops must honor `is_noninteractive()` (from `base.py`): when set, raise instead of looping, otherwise the test harness (`PYCLASHBOT_NONINTERACTIVE=1`) hangs. TRANSITIONAL scaffolding; don't build permanent behavior on it (see the `is_noninteractive()` docstring).
+- A not-ready emulator (app missing, signed out, no main menu, no clean instance) must `raise EmulatorNotReadyError` (from `base.py`) — never block on a GUI "Retry" prompt; there is no human-in-the-loop prompt path. `restart()` makes one boot attempt and raises on failure; the caller decides what to do (stop the bot on first boot, or fold it into the bounded mid-run restart net). Internal **timeout-bounded** waits are fine — unbounded retry loops are not.
 - Screenshots are `screencap -p` → `cv2.imdecode` → **BGR** numpy, expected ~**419×633**; a size mismatch triggers retry/recovery. **Card fingerprints** use this BGR order as-is in `card_detection.py`. Some `state_detect` helpers flip to RGB via `[..., ::-1]` for pixel constants.
 - Platform-locked: MEmu & Google Play are **Windows-only**; BlueStacks is Win+macOS. Gate paths with `is_windows()`/`is_macos()` from `utils.platform`.
 - Render modes differ per emulator and are written to that emulator's config file then require stop→edit→restart (MEmu int 0/1; BlueStacks `dx`/`gl`/`vlcn`, macOS defaults `vlcn`; Google Play XML).

--- a/pyclashbot/emulators/adb.py
+++ b/pyclashbot/emulators/adb.py
@@ -297,8 +297,8 @@ class AdbController(AdbBasedController):
         1. Force-stop the app.
         2. Start the app (using the base class method).
         3. Wait for the main menu to appear.
-        Returns:
-            bool: True if the app was successfully restarted and the main menu is found, False otherwise.
+        Returns True once the main menu is reached; raises EmulatorNotReadyError
+        if Clash isn't installed or the main menu never appears.
         """
         start_ts = time.time()
         self.logger.change_status("Restarting Clash Royale on device...")

--- a/pyclashbot/emulators/base.py
+++ b/pyclashbot/emulators/base.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 
 from pyclashbot.utils.platform import CURRENT_PLATFORM, Platform
@@ -8,26 +6,9 @@ CLASH_ROYALE_PACKAGE = "com.supercell.clashroyale"
 
 
 class EmulatorNotReadyError(RuntimeError):
-    """The emulator can't be made ready (app missing, signed out, no main menu)
-    and no human is available to fix it — raised instead of waiting forever.
-
-    TRANSITIONAL: part of the is_noninteractive() scaffolding below; see that
-    docstring for the removal plan.
-    """
-
-
-def is_noninteractive() -> bool:
-    """True when no GUI/human can resolve a setup prompt (e.g. the test harness);
-    controllers then raise EmulatorNotReadyError instead of looping on a "Retry"
-    click that never comes. Production never sets it, so its behavior is unchanged.
-
-    TRANSITIONAL SCAFFOLDING — the env var, this function, and every
-    `if is_noninteractive():` guard (tagged `TODO(noninteractive)`) delete
-    themselves once retry/prompt orchestration is lifted out of the adapters into
-    an application-layer port (adapters become "attempt once, return outcome";
-    callers own the retry loop). Do NOT build new permanent behavior on this flag.
-    """
-    return os.environ.get("PYCLASHBOT_NONINTERACTIVE") == "1"
+    """The emulator can't be made ready (app missing, signed out, no main menu) —
+    raised by `restart()` instead of waiting forever. Callers either stop the bot
+    (first boot) or fold it into the bounded mid-run restart net."""
 
 
 class BaseEmulatorController:
@@ -71,9 +52,11 @@ class BaseEmulatorController:
         """
         Full boot -> configure -> launch Clash -> reach main menu.
 
-        Returns True only when Clash Royale is left on a main menu detectable by
-        check_if_on_clash_main_menu(self); subclasses return False to trigger the
-        retry loop.
+        The single boot primitive, called explicitly after construction (and again
+        for mid-run recovery). One attempt: it returns True once Clash Royale is
+        left on a main menu detectable by check_if_on_clash_main_menu(self), and
+        raises EmulatorNotReadyError on any not-ready failure — it never returns
+        False.
         """
         raise NotImplementedError
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -42,8 +42,7 @@ and resolves a backend.
   Clash and reaches the main menu — MEmu/BlueStacks/Google Play boot the VM, while
   ADB attaches to an already-running device and (re)launches Clash. Either way a
   not-ready emulator (app missing, signed out, no main menu) fails fast there with
-  a clear `EmulatorNotReadyError` rather than hanging on a GUI prompt
-  (`PYCLASHBOT_NONINTERACTIVE=1`, set in integration mode).
+  a clear `EmulatorNotReadyError` rather than hanging on a GUI prompt.
 - A clash entry is a `run_test(emulator, logger) -> (bool, str)`. Add one by
   appending its `run_test` to `SUITE` in `test_jobs.py`; entries run with `-x` and
   set up later ones, so order matters.

--- a/tests/clash_royale/readme.md
+++ b/tests/clash_royale/readme.md
@@ -9,11 +9,12 @@ Order, the shared emulator, and backend resolution live in `test_jobs.py` and
 
 ## Setup is automatic
 
-No manual boot. During fixture construction the controller gets Clash to the main
-menu — MEmu/BlueStacks/Google Play boot the VM, while `adb` attaches to an
-already-running device and (re)launches Clash. If that can't be done (app missing,
-signed out, no main menu) the run aborts fast with a clear message instead of
-hanging. The first two `SUITE` entries then sanity-check the result:
+No manual boot. The fixture constructs the controller (cheap discovery/config)
+then calls `restart()` to get Clash to the main menu — MEmu/BlueStacks/Google Play
+boot the VM, while `adb` attaches to an already-running device and (re)launches
+Clash. If that can't be done (app missing, signed out, no main menu) the run aborts
+fast with a clear message instead of hanging. The first two `SUITE` entries then
+sanity-check the result:
 
 1. `app_installed` — Clash Royale is installed (fails fast, never waits on install).
 2. `screenshot_contract` — the capture pipeline returns a valid, non-black frame.

--- a/tests/clash_royale/test_jobs.py
+++ b/tests/clash_royale/test_jobs.py
@@ -28,9 +28,9 @@ from .navigation.test_navigate_main_pages import run_test as nav_main_pages
 
 # Fixed order — setup first (install check, then a screenshot smoke), cheap/safe
 # jobs next, the fight chain last. The emulator is already booted and on the main
-# menu by the time these run (controllers boot in construction; the fixture aborts
-# if that fails). switch_account is a round-trip (slot 1 -> 2 -> 1) so the rest of
-# the suite stays on slot 1.
+# menu by the time these run (the fixture constructs the controller then calls
+# restart() to boot, aborting the run if that fails). switch_account is a
+# round-trip (slot 1 -> 2 -> 1) so the rest of the suite stays on slot 1.
 SUITE = [
     ("app_installed", run_app_installed),
     ("screenshot_contract", screenshot_contract),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ never constructs an emulator or prompts.
 
 from __future__ import annotations
 
-import os
 import sys
 
 import pytest
@@ -97,11 +96,6 @@ def pytest_configure(config: pytest.Config) -> None:
     # Flip the default deselection (read lazily at collection, so setting it here
     # works). Intentionally overwrites any user-supplied `-m` under --integration.
     config.option.markexpr = "emulator"
-
-    # No GUI/human here: fail fast on a not-ready emulator instead of hanging on a
-    # "Retry" prompt. Set for the whole run (dedicated integration run, never unset).
-    # TRANSITIONAL — see is_noninteractive() in pyclashbot/emulators/base.py.
-    os.environ["PYCLASHBOT_NONINTERACTIVE"] = "1"
 
     choices = _emulator_choices()
     # Prior picks persist across runs via pytest's own cache (.pytest_cache/);


### PR DESCRIPTION
**Stacked on #709** (PR2). Review/merge that first — this branch targets `refactor/emulator-cleanup-pr2-construct-vs-boot`, so the diff shown is PR3-only.

## What

PR3 of the emulator-adapter cleanup: pure deletion of the transitional `is_noninteractive()` / `PYCLASHBOT_NONINTERACTIVE` scaffolding now that PR2 made the adapters fail fast **unconditionally**. The scaffolding's whole job was to make the test harness raise instead of hanging on a (broken) GUI "Retry" prompt — that prompt path is gone (PR1) and the raise is now the default in every adapter (PR2), so the gate guards nothing.

## Changes

- **`base.py`** — delete `is_noninteractive()` and the now-unused `import os`; trim the `EmulatorNotReadyError` docstring's TRANSITIONAL note; rewrite `restart()`'s docstring to the real contract (one boot attempt, returns `True` on success, raises `EmulatorNotReadyError` on failure, called explicitly after construction — no more "return False to trigger the retry loop").
- **`conftest.py`** — drop the `os.environ["PYCLASHBOT_NONINTERACTIVE"] = "1"` set and its now-unused `import os`.
- **`adb.py`** — fix `restart()`'s docstring that still promised a `False` return (it now returns `True` or raises). _(memu.py had the same fix; it migrated into #709 when the stack was rebased after the review pass, so it's no longer in this PR.)_
- **docs** — sync `emulators/AGENTS.md`, `tests/AGENTS.md`, `tests/clash_royale/readme.md`, and `test_jobs.py` to the construct-cheap / `restart()`-boots model.
- **new rule in `emulators/AGENTS.md`** — _"Adapters are ports — keep bot policy out."_ Retry counts, human prompts, give-up and mid-run-recovery decisions live in the caller (`bot/worker.py`, the test fixture), never an adapter — so the contract stays drivable by integration tests with no GUI or env-var scaffolding. This is the inverted principle behind the whole cleanup, stated so the next variation (a `max_attempts` param, an adapter reading user settings, a "wait for the user" hook) gets caught too — not just the symptoms the other gotchas already forbid.

## Verification

- [x] `grep` proves **zero** references to `is_noninteractive` / `PYCLASHBOT_NONINTERACTIVE` anywhere (src, tests, docs)
- [x] `make lint` clean
- [x] `make test` green (16 passed, 15 deselected)
- [x] `/agent-docs` — no doc references the deleted scaffolding; added the ports/policy rule (imperative, non-obvious, nested doc still under budget)
- [x] `/review` — deletion is safe (all four adapters raise unconditionally, no dangling refs, fixture still fails fast)

No emulator run needed — this PR changes no boot-path logic (PR2 already exercised the real boot sequence on macOS/BlueStacks).
