### PR TITLE
clash main deadspace click fix

### DIFF
--- a/pyclashbot/bot/coords.py
+++ b/pyclashbot/bot/coords.py
@@ -1,5 +1,5 @@
 # --- Clash main / global ---
-CLASH_MAIN_DEADSPACE_COORD = (35, 500)
+CLASH_MAIN_DEADSPACE_COORD = (30, 490)
 
 # --- Nav ---
 CLASH_MAIN_OPTIONS_BURGER_BUTTON = (390, 62)


### PR DESCRIPTION
Moves CLASH_MAIN_DEADSPACE_COORD from (35, 500) to (30, 490) so the clash main deadspace click lands on a safe spot.