### PR TITLE
refactor(emulators): re-land #708 (revert the mistaken revert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Default settings work for most users. Only enable "Show advanced settings" to ch
 
 - Must use BlueStacks 5, not BlueStacks X/10
 - Expected install path: `C:\Program Files\BlueStacks_nxt`
-- Startup fails: open Multi-Instance Manager, create fresh "Pie 64-bit" instance, leave other settings as default, click Retry in bot
+- Startup fails: open Multi-Instance Manager, create a fresh "Android 13 (Tiramisu 64-bit)" instance without signing into any Google account, leave other settings as default, then start the bot again
 - Black screen: switch render mode in bot settings
 
 ### Google Play Games

--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -8,7 +8,7 @@ import multiprocessing as mp
 import subprocess
 from multiprocessing import Event, Queue
 from os.path import expandvars, join
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 _original_setlocale = locale.setlocale
 
@@ -44,10 +44,6 @@ from pyclashbot.utils.discord_rpc import DiscordRPCManager
 from pyclashbot.utils.logger import Logger, initialize_pylogging, log_dir, log_name
 from pyclashbot.utils.open_folder import open_folder
 from pyclashbot.utils.platform import is_macos
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
 
 initialize_pylogging()
 
@@ -414,19 +410,6 @@ class BotApplication:
     def _update_ui_from_stats(self) -> None:
         update_layout(self.ui, self.logger, self._get_display_stats())
 
-    def _dispatch_action(self) -> None:
-        callback: Callable[[], None] | None = getattr(self.logger, "action_callback", None)
-        if callable(callback):
-            try:
-                callback()
-            except Exception as exc:
-                self.logger.log(f"Error executing action callback: {exc}")
-        if hasattr(self.logger, "action_needed"):
-            self.logger.action_needed = False
-            self.logger.action_callback = None
-            self.logger.action_text = "Continue"
-        self.ui.hide_action_button()
-
     def _poll(self) -> None:
         if self._closing:
             return
@@ -452,11 +435,6 @@ class BotApplication:
         self.process, self.logger = handle_process_finished(self.ui, self.process, self.logger)
         self._update_ui_from_stats()
         self.discord_rpc.sync(self.discord_rpc_enabled, self._get_display_stats())
-        if hasattr(self.logger, "action_needed") and self.logger.action_needed:
-            action_text = getattr(self.logger, "action_text", "Continue")
-            self.ui.show_action_button(action_text, self._dispatch_action)
-        else:
-            self.ui.hide_action_button()
         self.ui.after(100, self._poll)
 
     def _on_open_logs_clicked(self) -> None:

--- a/pyclashbot/emulators/AGENTS.md
+++ b/pyclashbot/emulators/AGENTS.md
@@ -4,14 +4,14 @@
 
 ## Adding an emulator
 
-- Subclass `AdbBasedController` if ADB-based — then you only implement `adb(command, binary_output)` and `_check_app_installed(package)`; everything else is inherited (including `is_app_installed`, the install-wait prompt loop, and the default `is_reachable()`). Otherwise subclass `BaseEmulatorController` and implement all abstract methods, including `is_app_installed(package) -> bool`.
+- Subclass `AdbBasedController` if ADB-based — then you only implement `adb(command, binary_output)` and `_check_app_installed(package)`; everything else is inherited (including `is_app_installed`, `start_app`, and the default `is_reachable()`). `start_app` raises `EmulatorNotReadyError` if the app isn't installed — there is no install-wait prompt; the bot fails fast. Otherwise subclass `BaseEmulatorController` and implement all abstract methods, including `is_app_installed(package) -> bool`.
 - `is_reachable() -> (ok, reason)` defaults to "a screenshot decodes to a non-empty array"; override it only if the backend exposes a truer liveness signal (MEmu checks VM running-state).
 - Take `logger` as the first `__init__` arg; set `supported_platforms`. `restart()` must leave Clash Royale on a main menu detectable by `check_if_on_clash_main_menu(self)`, else return `False` to trigger the retry loop.
 
 ## Gotchas
 
 - The Clash Royale package id lives in `base.py` as `CLASH_ROYALE_PACKAGE` — never re-inline the `"com.supercell.clashroyale"` string.
-- New boot/restart retry loops and install-wait prompts must honor `is_noninteractive()` (from `base.py`): when set, raise `EmulatorNotReadyError` instead of looping on a "Retry" no human will click — otherwise the test harness (`PYCLASHBOT_NONINTERACTIVE=1`) hangs. TRANSITIONAL scaffolding; don't build permanent behavior on it (see the `is_noninteractive()` docstring).
+- A not-ready emulator (app missing, signed out, no main menu, no clean instance) must `raise EmulatorNotReadyError` (from `base.py`) — never block on a GUI "Retry" prompt; there is no human-in-the-loop prompt path. New boot/restart retry loops must honor `is_noninteractive()` (from `base.py`): when set, raise instead of looping, otherwise the test harness (`PYCLASHBOT_NONINTERACTIVE=1`) hangs. TRANSITIONAL scaffolding; don't build permanent behavior on it (see the `is_noninteractive()` docstring).
 - Screenshots are `screencap -p` → `cv2.imdecode` → **BGR** numpy, expected ~**419×633**; a size mismatch triggers retry/recovery. **Card fingerprints** use this BGR order as-is in `card_detection.py`. Some `state_detect` helpers flip to RGB via `[..., ::-1]` for pixel constants.
 - Platform-locked: MEmu & Google Play are **Windows-only**; BlueStacks is Win+macOS. Gate paths with `is_windows()`/`is_macos()` from `utils.platform`.
 - Render modes differ per emulator and are written to that emulator's config file then require stop→edit→restart (MEmu int 0/1; BlueStacks `dx`/`gl`/`vlcn`, macOS defaults `vlcn`; Google Play XML).

--- a/pyclashbot/emulators/adb.py
+++ b/pyclashbot/emulators/adb.py
@@ -339,10 +339,3 @@ class AdbController(AdbBasedController):
 
         self.logger.change_status("Timeout waiting for Clash Royale main menu. Please check the device.")
         return False
-
-    # click() is now inherited from AdbBasedController
-    # swipe() is now inherited from AdbBasedController
-    # screenshot() is now inherited from AdbBasedController
-    # start_app() is now inherited from AdbBasedController
-    # _wait_for_clash_installation() is now inherited from AdbBasedController
-    # _retry_installation_check() is now inherited from AdbBasedController

--- a/pyclashbot/emulators/adb_base.py
+++ b/pyclashbot/emulators/adb_base.py
@@ -8,10 +8,8 @@ import cv2
 import numpy as np
 
 from pyclashbot.emulators.base import (
-    CLASH_ROYALE_PACKAGE,
     BaseEmulatorController,
     EmulatorNotReadyError,
-    is_noninteractive,
 )
 from pyclashbot.utils.cancellation import interruptible_sleep
 from pyclashbot.utils.platform import is_linux
@@ -280,64 +278,18 @@ class AdbBasedController(BaseEmulatorController, ABC):
         """
         Start an app using ADB monkey command.
 
-        If the app is not installed, it will trigger the
-        installation waiting mechanism.
-
         Args:
             package_name (str): The package name to start.
 
         Returns:
-            True if the app was started or if the installation
-            wait was successfully initiated and completed.
+            True if the app was launched.
+
+        Raises:
+            EmulatorNotReadyError: If the app is not installed.
         """
         if not self._check_app_installed(package_name):
-            return self._wait_for_clash_installation(package_name)
+            raise EmulatorNotReadyError(f"{package_name} is not installed on the emulator")
 
         logger.info("Launching app: %s", package_name)
         self.adb(f"shell monkey -p {package_name} -c android.intent.category.LAUNCHER 1")
         return True
-
-    def _wait_for_clash_installation(self, package_name: str):
-        """
-        Show a UI prompt and wait for the user to install the specified app.
-        """
-        self.current_package_name = package_name
-        if is_noninteractive():
-            raise EmulatorNotReadyError(f"{package_name} is not installed on the emulator")
-
-        logger.warning("App %s not installed - waiting for user to install", package_name)
-
-        if hasattr(self, "logger") and hasattr(self.logger, "show_temporary_action"):
-            self.logger.show_temporary_action(
-                message=f"{package_name} not installed - please install it and complete tutorial",
-                action_text="Retry",
-                callback=self._retry_installation_check,
-            )
-
-        self.installation_waiting = True
-
-        while self.installation_waiting:
-            interruptible_sleep(0.5)
-
-        logger.info("App %s installation confirmed", package_name)
-        return True
-
-    def _retry_installation_check(self):
-        """
-        Callback method for the 'Retry' button. Checks if the app has been installed.
-        """
-        logger.debug("Retry clicked - checking for app installation")
-
-        package_name = getattr(self, "current_package_name", CLASH_ROYALE_PACKAGE)
-
-        if self._check_app_installed(package_name):
-            self.installation_waiting = False
-            logger.info("App %s now installed", package_name)
-        else:
-            logger.warning("App %s still not installed", package_name)
-            if hasattr(self, "logger") and hasattr(self.logger, "show_temporary_action"):
-                self.logger.show_temporary_action(
-                    message=f"{package_name} still not found - please install it and complete tutorial",
-                    action_text="Retry",
-                    callback=self._retry_installation_check,
-                )

--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -397,49 +397,15 @@ class BlueStacksEmulatorController(AdbBasedController):
         if internal and self._reuse_and_rename_internal(internal):
             return
 
-        # Open Multi-Instance Manager and prompt user to create a clean instance.
-        while True:
-            self._request_instance_retry = False
-            self.logger.show_temporary_action(
-                message="No Android 13 instance found. Open BlueStacks Multi-Instance Manager and create a fresh Android 13 (Tiramisu 64-bit) instance without logging into any Google accounts, then click Retry.",
-                action_text="Retry",
-                callback=self._request_instance_creation_retry,
-            )
-            self.logger.log("[BlueStacks 5] No clean Android 13 instance found. Opening Multi-Instance Manager...")
+        # No clean instance to reuse and we won't create one unattended. Open the
+        # Multi-Instance Manager to help the user, but never let that mask the error.
+        with suppress(Exception):
             self._open_multi_instance_manager()
-
-            # Wait for user action via Retry callback
-            self.instance_creation_waiting = True
-            while getattr(self, "instance_creation_waiting", False):
-                interruptible_sleep(0.5)
-
-            # User clicked Retry check again for a clean instance outside the callback
-            if getattr(self, "_request_instance_retry", False):
-                # If our display name exists, resolve internal and port
-                if self._display_name_exists(self.bs_conf_path, self.instance_name):
-                    internal = self._find_internal_by_display_name(
-                        self.mim_meta_path, self.instance_name
-                    ) or self._find_internal_in_conf_by_display(self.bs_conf_path, self.instance_name)
-                    if internal:
-                        self.internal_name = internal
-                        self.instance_port = self._read_instance_adb_port(self.bs_conf_path, internal)
-                        with suppress(Exception):
-                            self._close_multi_instance_manager()
-                        self.logger.change_status("Clean instance detected - continuing...")
-                        return
-
-                # Otherwise try to reuse an unlinked instance
-                internal = self._pick_unlinked_instance()
-                if internal and self._reuse_and_rename_internal(internal):
-                    self.logger.change_status("Prepared clean instance - continuing...")
-                    return
-
-                self.logger.log("[BlueStacks 5] Still no clean Android 13 instance found. Please try again.")
-
-    def _request_instance_creation_retry(self):
-        self.logger.log("[BlueStacks 5] Retry clicked - rechecking for clean instance")
-        self._request_instance_retry = True
-        self.instance_creation_waiting = False
+        raise EmulatorNotReadyError(
+            "No clean Android 13 instance found — create a fresh Android 13 (Tiramisu 64-bit) "
+            "instance in the BlueStacks Multi-Instance Manager without logging into any Google "
+            "accounts, then start the bot again."
+        )
 
     def _apply_renderer_setting(self) -> None:
         desired = self.render_settings["graphics_renderer"]
@@ -705,13 +671,6 @@ class BlueStacksEmulatorController(AdbBasedController):
 
         self.logger.change_status("Timeout waiting for Clash Royale main menu — retrying...")
         return False
-
-    # click() is now inherited from AdbBasedController
-    # swipe() is now inherited from AdbBasedController
-    # screenshot() is now inherited from AdbBasedController
-    # start_app() is now inherited from AdbBasedController
-    # _wait_for_clash_installation() is now inherited from AdbBasedController
-    # _retry_installation_check() is now inherited from AdbBasedController
 
 
 if __name__ == "__main__":

--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -462,19 +462,11 @@ class GooglePlayEmulatorController(AdbBasedController):
             elif "not found" not in result.stderr.lower():
                 print(f"[!] Failed to terminate {proc}")
 
-    # click() is now inherited from AdbBasedController
-    # swipe() is now inherited from AdbBasedController
-    # screenshot() is now inherited from AdbBasedController
-
     def install_apk(self, apk_path: str):
         """
         This method is used to install an APK on the emulator.
         """
         raise NotImplementedError
-
-    # start_app() is now inherited from AdbBasedController
-    # _wait_for_clash_installation() is now inherited from AdbBasedController
-    # _retry_installation_check() is now inherited from AdbBasedController
 
     def debug_adb_connectivity(self):
         """

--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -1487,7 +1487,7 @@ class MemuEmulatorController(BaseEmulatorController):
         found = [app for app in installed_apps if package_name in app]
 
         if not found:
-            return self._wait_for_clash_installation(package_name)
+            raise EmulatorNotReadyError(f"{package_name} is not installed on the emulator")
 
         # start Clash Royale
         self.pmc.start_app_vm(package_name, vm_index=self.vm_index)
@@ -1510,51 +1510,6 @@ class MemuEmulatorController(BaseEmulatorController):
     def is_app_installed(self, package: str) -> bool:
         installed_apps = self.pmc.get_app_info_list_vm(vm_index=self.vm_index)
         return any(package in app for app in installed_apps)
-
-    def _wait_for_clash_installation(self, package_name: str):
-        """Wait for user to install Clash Royale using the logger action system"""
-        self.current_package_name = package_name  # Store for retry logic
-        if is_noninteractive():
-            raise EmulatorNotReadyError(f"{package_name} is not installed on the emulator")
-
-        self.logger.show_temporary_action(
-            message=f"{package_name} not installed - please install it and complete tutorial",
-            action_text="Retry",
-            callback=self._retry_installation_check,
-        )
-
-        self.logger.log(f"[!] {package_name} not installed.")
-        self.logger.log("Please install it in the emulator, complete tutorial, then click Retry in the GUI")
-
-        # Wait for the callback to be triggered
-        self.installation_waiting = True
-        while self.installation_waiting:
-            interruptible_sleep(0.5)
-
-        self.logger.log("[+] Installation confirmed, continuing...")
-        return True
-
-    def _retry_installation_check(self):
-        """Callback method triggered when user clicks Retry button"""
-        self.logger.change_status("Checking for Clash Royale installation...")
-
-        # Check if app is now installed
-        package_name = getattr(self, "current_package_name", CLASH_ROYALE_PACKAGE)
-        installed_apps = self.pmc.get_app_info_list_vm(vm_index=self.vm_index)
-        found = [app for app in installed_apps if package_name in app]
-
-        if found:
-            # Installation successful!
-            self.installation_waiting = False
-            self.logger.change_status("Installation complete - continuing...")
-        else:
-            # Still not installed, show the retry button again
-            self.logger.show_temporary_action(
-                message=f"{package_name} still not found - please install it and complete tutorial",
-                action_text="Retry",
-                callback=self._retry_installation_check,
-            )
-            self.logger.log(f"[!] {package_name} still not installed. Please try again.")
 
 
 if __name__ == "__main__":

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -362,21 +362,10 @@ class PyClashBotUI(ttk.Window):
         self._sync_job_extra_spinboxes()
         if self._job_toggle_checkbuttons:
             self._sync_all_job_toggle_appearances()
-        if running:
-            self._hide_action_button()
 
     def get_button_state(self) -> str:
         """Get the current button state: 'idle', 'running', or 'stopping'."""
         return self._button_state
-
-    def show_action_button(self, text: str, callback: Callable[[], None]) -> None:
-        self._action_callback = callback
-        self.action_btn.configure(text=text)
-        self.main_btn.grid_remove()
-        self.action_btn.grid()
-
-    def hide_action_button(self) -> None:
-        self._hide_action_button()
 
     def append_log(self, message: str) -> None:
         self.event_log.configure(state="normal")
@@ -587,12 +576,6 @@ class PyClashBotUI(ttk.Window):
         self.main_btn = ttk.Button(self._main_btn_row, text="Start", bootstyle="success")
         self.main_btn.grid(row=0, column=1, ipadx=ipadx, ipady=ipady)
         self._register_config_widget("main_btn", self.main_btn)
-
-        self.action_btn = ttk.Button(self._main_btn_row, text="Retry", bootstyle="secondary")
-        self.action_btn.grid(row=0, column=1, ipadx=ipadx, ipady=ipady)
-        self.action_btn.grid_remove()
-        self._action_callback: Callable[[], None] | None = None
-        self.action_btn.configure(command=self._on_action_pressed)
 
     def _create_jobs_tab(self) -> None:
         content = self._prepare_tab_page(self.jobs_tab)
@@ -1436,15 +1419,6 @@ class PyClashBotUI(ttk.Window):
 
         self._update_advanced_settings_visibility(selected_emulator)
         self.settings_container.update_idletasks()
-
-    def _hide_action_button(self) -> None:
-        self.action_btn.grid_remove()
-        self.main_btn.grid()
-
-    def _on_action_pressed(self) -> None:
-        if self._action_callback:
-            self._action_callback()
-        self._hide_action_button()
 
     def _on_open_logs_clicked(self) -> None:
         if self._open_logs_callback:

--- a/pyclashbot/utils/logger.py
+++ b/pyclashbot/utils/logger.py
@@ -187,11 +187,6 @@ class Logger:
         # track errored logger
         self.errored = False
 
-        # action system for UI callbacks
-        self.action_needed = False
-        self.action_callback = None
-        self.action_text = "Continue"
-
         # write initial values to queue
         self._update_stats()
 
@@ -492,36 +487,16 @@ class Logger:
         self.daily_rewards += 1
 
     @_updates_gui
-    def change_status(self, status, action_needed=False, action_callback=None) -> None:
+    def change_status(self, status) -> None:
         """Change status of bot in log
 
         Args:
         ----
             status (str): status of bot
-            action_needed (bool): whether an action button should be shown
-            action_callback (callable): callback function to call when action is taken
 
         """
         self.current_status = status
-        self.action_needed = action_needed
-        self.action_callback = action_callback
         self.log(status)
-
-    @_updates_gui
-    def show_temporary_action(self, message, action_text="Retry", callback=None) -> None:
-        """Show a temporary action button with the given message
-
-        Args:
-        ----
-            message (str): message to display to user
-            action_text (str): text for the action button
-            callback (callable): function to call when action is taken
-        """
-        self.current_status = message
-        self.action_needed = True
-        self.action_text = action_text
-        self.action_callback = callback
-        self.log(message)
 
     @_updates_gui
     def add_restart_after_failure(self) -> None:


### PR DESCRIPTION
## What

Re-lands **#708** by reverting `cc391693`, which reverted #708 by mistake.

#708 ("delete the broken human-in-the-loop Retry prompt stack") was reviewed, approved, and merged (squash `12076b6c`). The next morning it was reverted with a default auto-generated message and **no rationale** — confirmed with @matthewmiglio to have been a mistake. The revert restored 241 lines of the dead/deadlocking prompt code to `master`.

This PR is a straight **revert-of-the-revert** (`git revert cc391693`): **+19 / −241**, identical to #708's original diff. No new logic.

## Why it matters

#708 is the **base of the approved emulator-cleanup stack** — #709 (construct-vs-boot lifecycle) and #710 (delete transitional scaffolding) both sit on top of it. With #708's content reverted off `master`, that stack can't land cleanly. Restoring it here unblocks the stack.

## Merge order

1. **This PR** → `master` (restores #708's deletions).
2. Retarget **#709** base → `master`, merge.
3. Retarget **#710** base → `master`, merge.

## Verification

- [x] Diff is exactly the inverse of `cc391693` (the mistaken revert) = #708's original change.
- [x] `make lint` clean.
- [x] No emulator run needed — reproduces the previously-merged, CI-passed `12076b6c` tree state.
