### PR TITLE
feat(tooling): introduce ty type checker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ A Clash Royale automation bot: drives an Android emulator via ADB and acts on th
 
 ## Commands
 
-Targets live in the `Makefile` (`make setup`/`dev`/`lint`/`test`, `build-msi`/`build-dmg`, all via `uv`); `CONTRIBUTING.md` has dev setup. Non-obvious bits those don't tell you:
+Targets live in the `Makefile` (`make setup`/`dev`/`lint`/`test`/`type-check`, `build-msi`/`build-dmg`, all via `uv`); `CONTRIBUTING.md` has dev setup. Non-obvious bits those don't tell you:
 - Tests are **pytest**, offline by default (`addopts = -m "not emulator"`). Hardware tests carry `@pytest.mark.emulator`: `make test` runs only offline tests; `make test-emulator` runs the live-emulator suite. `--integration` flips the marker and resolves a backend (`--emulator`/cache/menu, platform-gated); the `emulator` fixture boots the emulator via `restart()`. See `tests/AGENTS.md`.
 - The clash suite is one parametrized test (`tests/clash_royale/test_jobs.py`) over an ordered `SUITE` list — add a job by appending its `run_test` to `SUITE`. Shared emulator + backend resolution live in `tests/conftest.py` + `tests/_emulator_support.py`. Select with `-k`, stop at first failure with `-x`.
 - `tests/clash_royale/` needs a live emulator and **does not run in CI** (CI only builds artifacts + runs pre-commit).
@@ -27,6 +27,7 @@ Targets live in the `Makefile` (`make setup`/`dev`/`lint`/`test`, `build-msi`/`b
 - Always verify screen state (a `check_if_on_*` / detection call) **before** clicking. Never hardcode a raw click — use named coordinate constants or nav helpers.
 - Persistent user settings go through `USER_SETTINGS_CACHE` (`pyclashbot.utils.caching`), keyed by `UIField.value` strings. Logging/stats go through `pyclashbot.utils.logger`; OS checks through `pyclashbot.utils.platform` (`is_windows()`/`is_macos()`).
 - Version is a `v0.0.0` placeholder in `pyproject.toml`; the real version is injected from the git tag at build time and read at runtime from `pyclashbot/__version__` via `utils/versioning.py`.
+- **Type checking is `ty`** (Astral), configured under `[tool.ty]` in `pyproject.toml` and enforced by pre-commit/CI; run it alone with `make type-check`. Suppress only genuine platform-gated false positives (Windows-only APIs), using `# ty: ignore[rule]` — never bare `# type: ignore`. A scoped override keeps ttkbootstrap's dynamic-kwarg noise in `interface/` at `warn`.
 - Python 3.12 only. Conventional-commit messages.
 
 ## Where new code goes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,15 +117,18 @@ Then create a pull request on GitHub with:
 
 The project uses several tools to maintain code quality:
 
-- **ruff** - Code linting and formatting
-- **isort** - Import sorting
+- **ruff** - Code linting and formatting (including import sorting)
+- **ty** - Static type checking
 - **pre-commit** - Automated code quality checks
 
 ### Running Code Quality Checks
 
 ```bash
-# Run all pre-commit checks on all files
+# Run all pre-commit checks on all files (includes ty)
 make lint
+
+# Run only the type checker
+make type-check
 ```
 
 ## Additional Guidelines

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ dev:
 lint:
 	uvx pre-commit run --all-files
 
+type-check:
+	uv run ty check
+
 # Offline by default (pytest addopts carries -m "not emulator"); safe everywhere.
 test:
 	uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "psutil>=6.1.0,<8",
     "pypresence>=4.3.0,<5",
     "pillow>=12.2.0,<13.0.0",
-    "ttkbootstrap>=1.12.1,<1.21",
+    "ttkbootstrap>=1.20.0,<1.21",
 ]
 
 [tool.setuptools.packages.find]
@@ -40,7 +40,12 @@ build = [
     "packaging>=24.2",
     "requests>=2.33.0",
 ]
-dev = ["pre-commit>=4.0.1,<5", "ruff>=0.7.4,<0.16", "pytest>=9.0.3,<10"]
+dev = [
+    "pre-commit>=4.0.1,<5",
+    "ruff>=0.7.4,<0.16",
+    "pytest>=9.0.3,<10",
+    "ty>=0.0.49",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -100,5 +105,19 @@ line-length = 120
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "time.sleep".msg = "Use interruptible_sleep() from pyclashbot.utils.cancellation instead for proper thread cancellation support."
 
-[tool.isort]
-profile = "black"
+[tool.ty.environment]
+python-version = "3.12"
+
+[tool.ty.analysis]
+# Build-time deps used by scripts/ live in the `build` dependency group
+# (platform-gated), which isn't installed in the default dev venv.
+allowed-unresolved-imports = ["cx_Freeze", "PyInstaller.**", "requests"]
+
+# ttkbootstrap >=1.18 ships stubs covering bootstyle= on its widgets, but calls
+# through tkinter base types (e.g. Misc.configure(foreground=...)) still hit
+# typeshed signatures that don't know ttkbootstrap's restyled kwargs.
+[[tool.ty.overrides]]
+include = ["pyclashbot/interface/**"]
+
+[tool.ty.overrides.rules]
+unknown-argument = "warn"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,9 +1,0 @@
-{
-    "exclude": [
-        "**/node_modules",
-        "**/__pycache__",
-        "**/build",
-        "**/dist",
-        "**/debug"
-    ]
-}

--- a/uv.lock
+++ b/uv.lock
@@ -327,6 +327,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -337,7 +338,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=6.1.0,<8" },
     { name = "pymemuc", specifier = ">=0.6.0,<0.7" },
     { name = "pypresence", specifier = ">=4.3.0,<5" },
-    { name = "ttkbootstrap", specifier = ">=1.12.1,<1.21" },
+    { name = "ttkbootstrap", specifier = ">=1.20.0,<1.21" },
 ]
 
 [package.metadata.requires-dev]
@@ -351,6 +352,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.1,<5" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "ruff", specifier = ">=0.7.4,<0.16" },
+    { name = "ty", specifier = ">=0.0.49" },
 ]
 
 [[package]]
@@ -502,12 +504,40 @@ wheels = [
 
 [[package]]
 name = "ttkbootstrap"
-version = "1.12.1"
+version = "1.20.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/62/c9c7c1897d59ddcea144e7c59636457d4b6e7a92f1faf1c29a96e08f2c2d/ttkbootstrap-1.12.1.tar.gz", hash = "sha256:7f599f8d52ba7f2ef48bd48359962de3682c7131b80b4e26bb9456f3c66dfee9", size = 128823, upload-time = "2025-04-27T20:47:10.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/88/bb1535edbd12e7b60223bee86241368b5d27043c001ef81d620ae8a56faf/ttkbootstrap-1.20.3.tar.gz", hash = "sha256:3350b80f79b0454c12558a7174c4bc4bd47905758843c3e8b0fbb19a0286fb69", size = 176262, upload-time = "2026-05-07T03:09:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/48/a5fd0d5d360e363f9bb289bef29b66103fd4ae1be1e3b6896a01b6e0f993/ttkbootstrap-1.20.3-py3-none-any.whl", hash = "sha256:95a05a4a663e3047be54edc220aa59c494a54f5c617a72a2c59a4bf634b97a5a", size = 191453, upload-time = "2026-05-07T03:09:24.935Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.49"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/8d/37cb91808069509d43a2a11743e12f1e854fd808dbef2203309d256718cd/ty-0.0.49.tar.gz", hash = "sha256:0a027bd0c9c75d035641a365d087ad883446057f9be0b9826251c2aecafbf145", size = 5884753, upload-time = "2026-06-12T03:08:20.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/de/9237c6a96356612dd0393db1e94cf21f903616adf3a3701bf3da6e4adc92/ty-0.0.49-py3-none-linux_armv6l.whl", hash = "sha256:12c0c4310b936d762a8586c210b53d4fa4bb361a04429afa89bf84b922e5e065", size = 11834671, upload-time = "2026-06-12T03:07:53.062Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/15/daf5a14a5e07012277d450c75325c94614e2acfec4c620c881486118c410/ty-0.0.49-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:737bfdc2caf9712a8580944dcdc80a450a37a4f2bc83c8fa9b7433b374f9e471", size = 11589570, upload-time = "2026-06-12T03:08:25.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/58/30bdf98436488aca25f0763bf7f92a061528d42461b686453029e845e4c5/ty-0.0.49-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab90c1baf3b1701d282fce4b02fa552a962d109f8972c46ef6b22429503bfea4", size = 10985236, upload-time = "2026-06-12T03:08:36.664Z" },
+    { url = "https://files.pythonhosted.org/packages/22/45/ece503e4a1396e13a1a9a0cde51afe476a6506a1d557eeadf8ad45c83bc0/ty-0.0.49-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4ce8ecf6ba6fc79bd137cc0557a754f7e5f2dfe9436412551d480d680e248ad", size = 11504302, upload-time = "2026-06-12T03:08:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dc/5d09333d289dfbca1804eaade125c9e8a1a992a2a592a8b80c5e9b589ca9/ty-0.0.49-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10d85c6865c984e78661e0bd20b180514b4a289739224e84816e342bdf381e04", size = 11626629, upload-time = "2026-06-12T03:08:06.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/155f41c9dd7237c4b609211f29f77755a139ee6218605dadc7fe21d5e3c8/ty-0.0.49-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d96a67a206619e01fa92f35a22267ec634bba62be24b1d0e947020cc179995b", size = 12074481, upload-time = "2026-06-12T03:08:09.643Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4c/998ee13cd5045f1f8b36982de7343163832ac53f27debe01b0de0e8bd968/ty-0.0.49-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de9f648564e0a66344ef397770387cb0d093735f8679d2c5a08a4741e79814d", size = 12678042, upload-time = "2026-06-12T03:08:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c9/9a505aba85c41ce54cbcaa14f8d79aa084b86151d2d70df11c4655b92898/ty-0.0.49-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5779179ab397d15f8c9dbb8f506ec1b1745f54eac639982f76ef3ce538943b50", size = 12316194, upload-time = "2026-06-12T03:08:18.023Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/ded37fb93503294abbc83c36470bb1413bea05048b745881d4470b518a06/ty-0.0.49-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792d4974e93cc09bd32f934586080bbbe21b8e777099cb521cb2de18b68a49f0", size = 12145507, upload-time = "2026-06-12T03:07:56.505Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/07/392e80d78f02445f695b815bb9eb0fffacda68b03faee38c900f7b990815/ty-0.0.49-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:727bda86deb136073e525c2e78d60e38aedcce5d80579170844a52bbf7c1440d", size = 12365967, upload-time = "2026-06-12T03:08:12.553Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/31b0c2a7fbedd3373e389cb1d81b8d2128f6f868fafb46557736a6f9aca8/ty-0.0.49-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4f2fc2bc4a8d2ff1cca59fd94772cabdfec4062d47a0b3a0784be46d94d0540b", size = 11475283, upload-time = "2026-06-12T03:08:28.334Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5b/329e101638920b468a3bb63059c9f66ef99b44aac501222c44832a507321/ty-0.0.49-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3724bd9badef333321578b6a941fbc571ebf49141ec2356a8590fbe4c9aa588d", size = 11645343, upload-time = "2026-06-12T03:08:15.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/76/c897e615e32f80ca81c8c1bc49b9a1f72ff9e3cfea0f8345ba505fe28472/ty-0.0.49-py3-none-musllinux_1_2_i686.whl", hash = "sha256:166c6eb52ee4af3c5a9bb267d165d93000daa55c6758cd8ff3199741fb75917d", size = 11725585, upload-time = "2026-06-12T03:08:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/fdb42ee239f618800842681af5bb8598117e74512c10974a8b7b9086a898/ty-0.0.49-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:91e81d832c287b05782ee32eb1b801f62c1fa08df37d589d2b88c3f1d51c9731", size = 12237261, upload-time = "2026-06-12T03:08:31.105Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0f/a2d6a5fc9d0786cbeb3c200786da4e18c203589be3984bb5def83ca92320/ty-0.0.49-py3-none-win32.whl", hash = "sha256:7186af5ca9829d1f5d8916bcf767b8e819bfbf61b1b8ec843bb3fc699cb502e1", size = 11100789, upload-time = "2026-06-12T03:07:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9d/473ac8bc57b5a2d121da893bf9dd74a118efb19a01d711df1a6e397f05cc/ty-0.0.49-py3-none-win_amd64.whl", hash = "sha256:ae2142fc126a01effcca0c222908b0e6654b5ba1266d4e4d406e4866aef8e1d1", size = 12204644, upload-time = "2026-06-12T03:08:04.327Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a2/8959249da951ba3977fee20e688d28678b8a1d30a9ed4464228a85d45853/ty-0.0.49-py3-none-win_arm64.whl", hash = "sha256:75d5e2e7649765f31f4bed6c8adb149a75b18edd3fa6336dac4d0efc1a66466f", size = 11558965, upload-time = "2026-06-12T03:08:23.012Z" },
+]
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
## Summary

Adopts [ty](https://docs.astral.sh/ty/) (Astral's type checker, v0.0.49) — the repo previously had no enforced type checking (only a vestigial `pyrightconfig.json`).

- **dev dependency + `[tool.ty]` config** in `pyproject.toml`: Python 3.12 pinned (ty defaults to 3.14), `allowed-unresolved-imports` for build-script deps (`cx_Freeze`/`PyInstaller`/`requests` live in the platform-gated `build` group), and a scoped `[[tool.ty.overrides]]` keeping `unknown-argument` at `warn` for `pyclashbot/interface/**` (tkinter typeshed stubs don't model ttkbootstrap's restyled `configure()` kwargs)
- **`make type-check`** target
- **ttkbootstrap lock bump 1.12.1 → 1.20.3** and declared floor raised to `>=1.20.0`: 1.18+ ships official PEP 561 stubs (covers `bootstyle=` on widgets, clearing ~16 diagnostics), and #715 uses `ttkbootstrap.widgets.ToolTip` which doesn't exist before 1.18
- **legacy config cleanup**: drop `pyrightconfig.json` and the dead `[tool.isort]` section (ruff owns import sorting); document ty in `AGENTS.md` + `CONTRIBUTING.md`

**Enforcement is intentionally not in this PR**: the ty pre-commit hook lands in the stacked #715 together with the fixes for all 93 existing diagnostics, so every PR in the stack is green standalone. Until #715 merges, ty is available (`make type-check`) but not gating.

## Test plan

- `pre-commit run --all-files` and `make test` green on this branch standalone
- Full stack (#715) green incl. the ty hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)