### PR TITLE
fix(typing): resolve all ty diagnostics and enable enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,7 @@ repos:
       - id: ruff-format
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.49
+    hooks:
+      - id: ty

--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -6,22 +6,31 @@ import locale
 import logging
 import multiprocessing as mp
 import subprocess
-from multiprocessing import Event, Queue
+from multiprocessing import Queue
 from os.path import expandvars, join
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from multiprocessing.synchronize import Event
 
 _original_setlocale = locale.setlocale
+_LocaleError = locale.Error
 
 
-def _setlocale_safe(category: int, loc: str | None = None) -> str:
+# Parameter name must match the stdlib's (callers may pass locale= by keyword);
+# it shadows the locale module inside the body, hence the module-level aliases.
+def _setlocale_safe(category: int, locale: str | Iterable[str | None] | None = None) -> str:
     """Fallback to the C locale if the requested locale is unsupported."""
     try:
-        return _original_setlocale(category, loc)
-    except locale.Error:
+        return _original_setlocale(category, locale)
+    except _LocaleError:
         return _original_setlocale(category, "C")
 
 
-locale.setlocale = _setlocale_safe  # type: ignore[assignment]
+# Deliberate monkeypatch; ty rejects reassigning a module-level function even with
+# a matching signature, so suppress rather than launder the type.
+locale.setlocale = _setlocale_safe  # ty: ignore[invalid-assignment]
 
 try:
     # Force a portable locale so ttkbootstrap does not raise unsupported locale errors on non-English systems.

--- a/pyclashbot/bot/card_detection.py
+++ b/pyclashbot/bot/card_detection.py
@@ -387,7 +387,7 @@ CARD_ATTRIBUTES: dict[str, dict[str, str]] = {
     "skeleton_barrel": {"type": "Spell", "subtype": "Surprise pressure"},
 }
 
-# card color data
+# card color data (initially holds dict[str, int] entries, then transformed to ndarray)
 card_color_data = {
     "archer_queen": [
         {
@@ -11537,8 +11537,17 @@ COLORS_ARRAY = numpy.array(list(COLORS.values()))
 COLORS_KEYS = list(COLORS.keys())
 
 # Pre-compute numpy arrays for each card's corner data
+# Build a fresh dict with the transformed values
+_card_color_data_transformed: dict[str, list[numpy.ndarray[tuple[int, ...], numpy.dtype[numpy.int64]]]] = {}
 for card_name, card_data in card_color_data.items():
-    card_color_data[card_name] = [numpy.array(list(corner.values())) for corner in card_data]
+    if isinstance(card_data[0], dict):
+        _card_color_data_transformed[card_name] = [numpy.array(list(corner.values())) for corner in card_data]
+    else:
+        # Already transformed
+        _card_color_data_transformed[card_name] = card_data
+card_color_data: dict[str, list[numpy.ndarray[tuple[int, ...], numpy.dtype[numpy.int64]]]] = (
+    _card_color_data_transformed
+)
 
 
 def calculate_offset(card_name, card_data, collected_data_array):
@@ -11657,10 +11666,8 @@ card_coords = [
     for topleft in card_toplefts
 ]
 
-global play_side  # noqa: PLW0604
-global battle_iar  # noqa: PLW0604
-
 play_side = "left"
+battle_iar: numpy.ndarray[tuple[int, ...], numpy.dtype[numpy.uint8]] | None = None
 
 
 def is_hero_champion_ability_visible(emulator) -> bool:
@@ -11763,7 +11770,7 @@ def calculate_play_coords(card_grouping: str, side_preference: str, elapsed_time
             return random.choice(group_datum["coords"])
 
 
-bridge_iar = 0
+bridge_iar: numpy.ndarray[tuple[int, ...], numpy.dtype[numpy.uint8]] | None = None
 
 
 def create_default_bridge_iar(emulator):
@@ -11775,6 +11782,8 @@ bridge_pixel = [[100, 200], [275, 200]]
 
 
 def switch_side():
+    assert battle_iar is not None, "battle_iar must be set before calling switch_side()"
+    assert bridge_iar is not None, "bridge_iar must be set before calling switch_side()"
     bridge_color_offset = []
     for i, bridge in enumerate(bridge_pixel):
         all_coords = [(y, x) for x in range(bridge[0], bridge[0] + 40) for y in range(bridge[1], bridge[1] + 175)]

--- a/pyclashbot/bot/worker.py
+++ b/pyclashbot/bot/worker.py
@@ -1,5 +1,6 @@
 import traceback
-from multiprocessing import Event, Process, Queue
+from multiprocessing import Process, Queue
+from multiprocessing.synchronize import Event
 from typing import Any
 
 from pyclashbot.bot.states import StateHistory, StateOrder, state_tree

--- a/pyclashbot/emulators/base.py
+++ b/pyclashbot/emulators/base.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from pyclashbot.utils.platform import CURRENT_PLATFORM, Platform
+
+if TYPE_CHECKING:
+    from pyclashbot.utils.logger import Logger
 
 CLASH_ROYALE_PACKAGE = "com.supercell.clashroyale"
 
@@ -15,6 +22,10 @@ class BaseEmulatorController:
     """
     Base class for emulator controllers.
     This class is used to define the interface for all emulator controllers.
+
+    All concrete subclasses must accept logger as the first positional argument
+    and may accept additional keyword arguments (render_settings, device_serial,
+    render_mode, etc.) depending on their needs.
     """
 
     supported_platforms: list[Platform] = []
@@ -24,7 +35,17 @@ class BaseEmulatorController:
         """Check if this emulator is supported on the current platform."""
         return CURRENT_PLATFORM in cls.supported_platforms
 
-    def __init__(self):
+    def __init__(self, logger: Logger, *args: object, **kwargs: object) -> None:
+        """Initialize emulator controller.
+
+        Args:
+            logger: Project Logger for status updates (subclasses take it first).
+            *args, **kwargs: Subclass-specific extras (render_settings,
+                device_serial, render_mode, ...).
+
+        Raises:
+            NotImplementedError: Always raised; this base class must be subclassed.
+        """
         raise NotImplementedError
 
     def __del__(self):

--- a/pyclashbot/emulators/bluestacks.py
+++ b/pyclashbot/emulators/bluestacks.py
@@ -31,11 +31,11 @@ class BlueStacksEmulatorController(AdbBasedController):
     # so classmethods (e.g. discover_devices) can route to the right server.
     adb_server_port: int = 5041
 
-    @staticmethod
-    def find_adb() -> str | None:
+    @classmethod
+    def find_adb(cls) -> str | None:
         """Find bundled HD-Adb path, or None if not found."""
         try:
-            install = BlueStacksEmulatorController._find_install_location()
+            install = cls._find_install_location()
             adb = os.path.join(install, "hd-adb" if is_macos() else "HD-Adb.exe")
             return adb if os.path.isfile(adb) else None
         except Exception:
@@ -149,11 +149,11 @@ class BlueStacksEmulatorController(AdbBasedController):
 
         reg_paths = [r"SOFTWARE\BlueStacks_nxt"]
         with suppress(FileNotFoundError, OSError):
-            reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+            reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)  # ty: ignore[unresolved-attribute]
             for subkey in reg_paths:
                 with suppress(FileNotFoundError, OSError):
-                    with winreg.OpenKey(reg, subkey) as k:
-                        val = winreg.QueryValueEx(k, value_name)[0]
+                    with winreg.OpenKey(reg, subkey) as k:  # ty: ignore[unresolved-attribute]
+                        val = winreg.QueryValueEx(k, value_name)[0]  # ty: ignore[unresolved-attribute]
                         if isinstance(val, str) and val.strip():
                             return val
         return None
@@ -322,7 +322,9 @@ class BlueStacksEmulatorController(AdbBasedController):
             subprocess.Popen(["open", "/Applications/BlueStacksMIM.app"])
         else:
             with suppress(Exception):
-                os.startfile(os.path.join(self.base_folder, "HD-MultiInstanceManager.exe"))
+                os.startfile(  # ty: ignore[unresolved-attribute]
+                    os.path.join(self.base_folder, "HD-MultiInstanceManager.exe")
+                )
 
     def _reuse_and_rename_internal(self, internal: str) -> bool:
         conf = self._read_text(self.bs_conf_path)

--- a/pyclashbot/emulators/google_play.py
+++ b/pyclashbot/emulators/google_play.py
@@ -22,11 +22,11 @@ class GooglePlayEmulatorController(AdbBasedController):
     # Default device serial for Google Play Games emulator
     DEFAULT_DEVICE_SERIAL = "localhost:6520"
 
-    @staticmethod
-    def find_adb() -> str | None:
+    @classmethod
+    def find_adb(cls) -> str | None:
         """Find bundled adb.exe path, or None if not found."""
         try:
-            install = GooglePlayEmulatorController._find_install_location()
+            install = cls._find_install_location()
             adb = os.path.join(install, "current", "emulator", "adb.exe")
             return adb if os.path.isfile(adb) else None
         except Exception:
@@ -233,8 +233,12 @@ class GooglePlayEmulatorController(AdbBasedController):
 
         for key in registry_keys:
             with suppress(FileNotFoundError):
-                with winreg.OpenKey(winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE), key) as reg_key:
-                    install_path = winreg.QueryValueEx(reg_key, "InstallLocation")[0]
+                with winreg.OpenKey(  # ty: ignore[unresolved-attribute]
+                    winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE),  # ty: ignore[unresolved-attribute]
+                    key,
+                ) as reg_key:
+                    value = winreg.QueryValueEx(reg_key, "InstallLocation")  # ty: ignore[unresolved-attribute]
+                    install_path = value[0]
                     folder_path = normpath(install_path)
                     if os.path.exists(folder_path) and os.path.isdir(folder_path):
                         return folder_path
@@ -422,7 +426,7 @@ class GooglePlayEmulatorController(AdbBasedController):
         """
         Starts the emulator using the Windows shell to open the shortcut.
         """
-        os.startfile(self.emulator_executable_path)
+        os.startfile(self.emulator_executable_path)  # ty: ignore[unresolved-attribute]
         interruptible_sleep(5)
 
     def stop(self):

--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -758,7 +758,10 @@ class MemuEmulatorController(BaseEmulatorController):
 
         console_path = join(self.pmc._get_memu_top_level(), "MEMuConsole.exe")
         self.logger.log("[+] Starting memu console at:" + str(console_path))
-        process = subprocess.Popen(console_path, creationflags=subprocess.DETACHED_PROCESS)
+        process = subprocess.Popen(
+            console_path,
+            creationflags=subprocess.DETACHED_PROCESS,  # ty: ignore[unresolved-attribute]
+        )
 
         interruptible_sleep(2)
 

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import LEFT, READONLY, YES, X
 from ttkbootstrap.style import Colors
-from ttkbootstrap.tooltip import ToolTip
+from ttkbootstrap.widgets import ToolTip
 
 from pyclashbot.emulators import EmulatorType, get_available_emulators
 from pyclashbot.interface.config import (
@@ -157,6 +157,9 @@ class PyClashBotUI(ttk.Window):
         self._traces: list[tuple[tk.Variable, str]] = []
         self._suspend_traces = 0
         self._button_state = "idle"
+        self.deck_var: ttk.StringVar | None = None
+        self.max_deck_var: ttk.StringVar | None = None
+        self.max_account_var: ttk.StringVar | None = None
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)  # Tab area absorbs extra height
@@ -181,13 +184,19 @@ class PyClashBotUI(ttk.Window):
                 stored = not stored
             values[field.value] = stored
 
-        values[UIField.DECK_NUMBER_SELECTION.value] = self._safe_int(self.deck_var.get(), fallback=2)
+        values[UIField.DECK_NUMBER_SELECTION.value] = self._safe_int(
+            self.deck_var.get() if self.deck_var is not None else "2", fallback=2
+        )
         values[UIField.CYCLE_DECKS_USER_TOGGLE.value] = bool(self.jobs_vars[UIField.CYCLE_DECKS_USER_TOGGLE].get())
-        values[UIField.MAX_DECK_SELECTION.value] = self._safe_int(self.max_deck_var.get(), fallback=2)
+        values[UIField.MAX_DECK_SELECTION.value] = self._safe_int(
+            self.max_deck_var.get() if self.max_deck_var is not None else "2", fallback=2
+        )
         values[UIField.SWITCH_ACCOUNTS_USER_TOGGLE.value] = bool(
             self.jobs_vars[UIField.SWITCH_ACCOUNTS_USER_TOGGLE].get()
         )
-        values[UIField.MAX_ACCOUNT_SELECTION.value] = self._safe_int(self.max_account_var.get(), fallback=2)
+        values[UIField.MAX_ACCOUNT_SELECTION.value] = self._safe_int(
+            self.max_account_var.get() if self.max_account_var is not None else "2", fallback=2
+        )
         emulator_choice = self.emulator_var.get()
         values[UIField.MEMU_EMULATOR_TOGGLE.value] = emulator_choice == EmulatorType.MEMU
         values[UIField.GOOGLE_PLAY_EMULATOR_TOGGLE.value] = emulator_choice == EmulatorType.GOOGLE_PLAY
@@ -225,11 +234,11 @@ class PyClashBotUI(ttk.Window):
                         ui_value = not ui_value
                     var.set(ui_value)
 
-            if UIField.DECK_NUMBER_SELECTION.value in values:
+            if UIField.DECK_NUMBER_SELECTION.value in values and self.deck_var is not None:
                 self.deck_var.set(str(values[UIField.DECK_NUMBER_SELECTION.value]))
-            if UIField.MAX_DECK_SELECTION.value in values:
+            if UIField.MAX_DECK_SELECTION.value in values and self.max_deck_var is not None:
                 self.max_deck_var.set(str(values[UIField.MAX_DECK_SELECTION.value]))
-            if UIField.MAX_ACCOUNT_SELECTION.value in values:
+            if UIField.MAX_ACCOUNT_SELECTION.value in values and self.max_account_var is not None:
                 self.max_account_var.set(str(values[UIField.MAX_ACCOUNT_SELECTION.value]))
             if UIField.THEME_NAME.value in values:
                 theme_value = str(values[UIField.THEME_NAME.value])
@@ -388,7 +397,7 @@ class PyClashBotUI(ttk.Window):
         def as_int(field: StatField) -> int:
             value = stats.get(field.value)
             try:
-                return int(value)
+                return int(str(value))
             except (TypeError, ValueError):
                 return 0
 
@@ -493,13 +502,22 @@ class PyClashBotUI(ttk.Window):
             command = config["command"]
             style = config.get("style")
             bootstyle = config.get("bootstyle")
-            pady = config.get("pady", (0, 0))
-            kwargs: dict[str, object] = {"text": text, "command": command}
-            if style is not None:
-                kwargs["style"] = style
-            if bootstyle is not None:
-                kwargs["bootstyle"] = bootstyle
-            button = ttk.Button(cluster, **kwargs)
+            pady_raw = config.get("pady", (0, 0))
+            if isinstance(pady_raw, int):
+                pady: tuple[int, int] | int = pady_raw
+            elif isinstance(pady_raw, tuple) and len(pady_raw) == 2:
+                a, b = pady_raw
+                pady = (int(str(a)), int(str(b)))
+            else:
+                pady = (0, 0)
+            if style is not None and bootstyle is not None:
+                button = ttk.Button(cluster, text=text, command=command, style=str(style), bootstyle=str(bootstyle))
+            elif style is not None:
+                button = ttk.Button(cluster, text=text, command=command, style=str(style))
+            elif bootstyle is not None:
+                button = ttk.Button(cluster, text=text, command=command, bootstyle=str(bootstyle))
+            else:
+                button = ttk.Button(cluster, text=text, command=command)
             padx = (0, 10) if index < last_index else (0, 0)
             button.pack(side=LEFT, ipadx=12, ipady=1, padx=padx, pady=pady)
             created.append(button)
@@ -530,7 +548,8 @@ class PyClashBotUI(ttk.Window):
             with Image.open(icon_path) as source:
                 resized = source.resize((64, 64), Image.Resampling.LANCZOS)
                 self._window_icon = ImageTk.PhotoImage(resized)
-            self.iconphoto(True, self._window_icon)
+            # PIL ImageTk.PhotoImage is _PhotoImageLike-compatible but not in tkinter stubs.
+            self.iconphoto(True, self._window_icon)  # ty: ignore[invalid-argument-type]
         except (ImportError, OSError, tk.TclError):
             return
 
@@ -600,8 +619,8 @@ class PyClashBotUI(ttk.Window):
             spin_var = ttk.StringVar(value=str(combo_config.default))
             spinbox = ttk.Spinbox(
                 parent,
-                from_=min(combo_config.values),
-                to=max(combo_config.values),
+                from_=int(min(combo_config.values)),
+                to=int(max(combo_config.values)),
                 width=3,
                 textvariable=spin_var,
                 command=self._notify_config_change,
@@ -853,7 +872,7 @@ class PyClashBotUI(ttk.Window):
 
         ttk.Label(device_row, text="Device:").grid(row=0, column=0, padx=(0, 5), sticky="w")
 
-        self.gp_device_serial_var = ttk.StringVar(value=GOOGLE_PLAY_DEVICE_CONFIG.default)
+        self.gp_device_serial_var = ttk.StringVar(value=str(GOOGLE_PLAY_DEVICE_CONFIG.default))
         self.gp_device_serial_combo = self._picker_combobox(
             device_row,
             textvariable=self.gp_device_serial_var,
@@ -903,7 +922,7 @@ class PyClashBotUI(ttk.Window):
 
         ttk.Label(device_row, text="Device:").grid(row=0, column=0, padx=(0, 5), sticky="w")
 
-        self.bs_device_serial_var = ttk.StringVar(value=BLUESTACKS_DEVICE_CONFIG.default)
+        self.bs_device_serial_var = ttk.StringVar(value=str(BLUESTACKS_DEVICE_CONFIG.default))
         self.bs_device_serial_combo = self._picker_combobox(
             device_row,
             textvariable=self.bs_device_serial_var,
@@ -1014,11 +1033,15 @@ class PyClashBotUI(ttk.Window):
         gauge_frame.grid(row=0, column=0, sticky="ew")
         gauge_frame.columnconfigure(0, weight=1)
 
+        _gauge_kw = self._initial_gauge_kwargs()
         self.win_gauge = DualRingGauge(
             gauge_frame,
             diameter=_WIN_GAUGE_DIAMETER,
             thickness=_WIN_GAUGE_THICKNESS,
-            **self._initial_gauge_kwargs(),
+            fg=_gauge_kw["fg"],
+            bg=_gauge_kw["bg"],
+            text_color=_gauge_kw["text_color"],
+            canvas_bg=_gauge_kw["canvas_bg"],
         )
         self.win_gauge.grid(row=0, column=0, pady=(0, 6))
 
@@ -1178,7 +1201,8 @@ class PyClashBotUI(ttk.Window):
             return
         if self._button_state == "idle":
             self._sync_start_button_readiness()
-        self.after_idle(lambda: self._config_callback(self.get_all_values()))
+        callback = self._config_callback
+        self.after_idle(lambda: callback(self.get_all_values()))
 
     def _trace_variable(self, var: tk.Variable) -> None:
         trace_id = var.trace_add("write", self._notify_config_change)
@@ -1450,7 +1474,7 @@ class PyClashBotUI(ttk.Window):
     @staticmethod
     def _safe_int(value: object, fallback: int = 0) -> int:
         try:
-            return int(value)
+            return int(str(value))
         except (TypeError, ValueError):
             return fallback
 

--- a/pyclashbot/interface/widgets.py
+++ b/pyclashbot/interface/widgets.py
@@ -82,7 +82,8 @@ class DualRingGauge(tk.Canvas):
             width=self.thickness,
             outline=outline,
         )
-        self.itemconfig(self._text, text=label, fill=text_colour or self.text_colour)
+        if self._text is not None:
+            self.itemconfig(self._text, text=label, fill=text_colour or self.text_colour)
         self._value = percent
 
     def animate_to(

--- a/pyclashbot/utils/image_handler.py
+++ b/pyclashbot/utils/image_handler.py
@@ -1,7 +1,9 @@
 from os.path import exists
+from typing import cast
 
 import cv2
 import numpy as np
+import numpy.typing as npt
 
 
 class InvalidImageError(Exception):
@@ -14,8 +16,8 @@ class InvalidImageError(Exception):
 
 
 def open_from_buffer(
-    image_data: bytes | bytearray | memoryview | np.ndarray[any],
-) -> np.ndarray[np.uint8]:
+    image_data: bytes | bytearray | memoryview | npt.NDArray[np.uint8],
+) -> npt.NDArray[np.uint8]:
     """A method to read an image from a byte array
     :param byte_array: the byte array to read the image from
     :return: the image as a numpy array
@@ -36,10 +38,10 @@ def open_from_buffer(
         raise InvalidImageError(
             "image_data bytes are not a valid image. Image is all white or all black",
         )
-    return img
+    return cast("npt.NDArray[np.uint8]", img)
 
 
-def open_from_path(path: str) -> np.ndarray[np.uint8]:
+def open_from_path(path: str) -> npt.NDArray[np.uint8]:
     """A method to validate and open an image file
     :param path: the path to the image file
     :return: the image as a numpy array

--- a/pyclashbot/utils/logger.py
+++ b/pyclashbot/utils/logger.py
@@ -587,7 +587,7 @@ class ProcessLogger(Logger):
         """Override to send stats through queue instead of just updating local dict."""
         super()._update_log()
         # Non-blocking put to queue - if queue is full, skip this update
-        if self._stats_queue is not None:
+        if self._stats_queue is not None and self.stats is not None:
             try:
                 self._stats_queue.put_nowait(self.stats.copy())
             except Exception:

--- a/pyclashbot/utils/machine_info.py
+++ b/pyclashbot/utils/machine_info.py
@@ -13,7 +13,7 @@ from pyclashbot.utils.subprocess import run
 def safe_get_user32():
     """Safely get user32 dll, return None if failed."""
     try:
-        return ctypes.windll.user32
+        return ctypes.windll.user32  # ty: ignore[unresolved-attribute]  # Windows-only API
     except Exception:
         return None
 

--- a/pyclashbot/utils/open_folder.py
+++ b/pyclashbot/utils/open_folder.py
@@ -15,7 +15,7 @@ def open_folder(folder_path: str) -> None:
 
     try:
         if is_windows():
-            os.startfile(folder_path)  # type: ignore[attr-defined]
+            os.startfile(folder_path)  # ty: ignore[unresolved-attribute]  # Windows-only API
             return
 
         if is_macos():

--- a/pyclashbot/utils/subprocess.py
+++ b/pyclashbot/utils/subprocess.py
@@ -15,7 +15,7 @@ if WIN32:
         SW_HIDE,
     )
 
-    ST_INFO = STARTUPINFO()  # pyright: ignore [reportConstantRedefinition]
+    ST_INFO = STARTUPINFO()
     ST_INFO.dwFlags |= STARTF_USESHOWWINDOW | STARTF_USESTDHANDLES | REALTIME_PRIORITY_CLASS
     ST_INFO.wShowWindow = SW_HIDE
     CR_FLAGS = CREATE_NO_WINDOW
@@ -28,7 +28,7 @@ else:
     subprocess_flags = {}
 
 
-def _terminate_process(  # pyright: ignore [reportUnusedFunction]
+def _terminate_process(
     process: Popen[str],
 ) -> None:
     """Terminate a process forcefully on Windows."""

--- a/tests/test_emulator_setup_failfast.py
+++ b/tests/test_emulator_setup_failfast.py
@@ -10,6 +10,7 @@ import pytest
 
 from pyclashbot.emulators import EmulatorType
 from pyclashbot.emulators.base import EmulatorNotReadyError
+from pyclashbot.utils.logger import Logger
 
 
 class _FakeNotReadyController:
@@ -25,15 +26,23 @@ class _FakeNotReadyController:
         raise EmulatorNotReadyError("fake emulator is not ready")
 
 
-class _RecordingLogger:
+class _RecordingLogger(Logger):
+    """Test double that inherits from Logger but records change_status calls.
+
+    Lightweight to construct (Logger.__init__ only sets instance attrs + locks,
+    doesn't spawn threads), and reuses all real Logger behavior without needing
+    to duplicate its interface.
+    """
+
     def __init__(self):
+        super().__init__(stats=None, timed=False)
         self.statuses: list[str] = []
 
-    def change_status(self, status):
+    def change_status(self, status) -> None:
+        """Override to record calls for assertions."""
         self.statuses.append(status)
-
-    def log(self, *args, **kwargs):
-        pass
+        # Still call parent to maintain contract (calls _update_log)
+        super().change_status(status)
 
 
 def test_attach_emulator_reraises_when_restart_not_ready(monkeypatch):


### PR DESCRIPTION
## Summary

Stacked on #714. Burns down every diagnostic ty reports (93 → 0 errors), **then turns on the ty pre-commit hook in this same PR** — enforcement (which gates CI via the existing pre-commit workflow) starts exactly when the codebase passes. Leaves only 5 `warn`-severity notes under the scoped `interface/**` override (tkinter typeshed can't model ttkbootstrap's restyled `Misc.configure(state=/foreground=)` kwargs).

Work was split into 6 file-disjoint packages, each fixed by an agent under a strict no-cheap-suppressions policy and then **independently review-verified for behavior preservation** (call-graph traces for every guard/assert; runtime checks for the GUI changes).

- **emulators**: honest `BaseEmulatorController.__init__` signature (project `Logger` + subclass extras) so registry construction via `type[BaseEmulatorController]` typechecks; `find_adb` overrides aligned to the base classmethod; Windows-only APIs (`winreg`, `os.startfile`, `DETACHED_PROCESS`) suppressed inline with `# ty: ignore[rule]` after verifying each is platform-gated
- **worker / `__main__`**: annotate with `multiprocessing.synchronize.Event` (the factory isn't a type); widen the locale shim to the stdlib `setlocale` signature — the monkeypatch assignment itself carries a documented ignore (ty can't prove module-function reassignment, and the agent's first "fix" turned out to launder the type through an unannotated factory; rejected in review)
- **card_detection**: declare `battle_iar`/`bridge_iar` globals honestly (`bridge_iar` sentinel `0` → `None`); assert initialization in `switch_side` (verified: both globals are always set first on the only call path, and the failure mode under `-O` is the same crash one line later)
- **interface**: declare conditionally-created StringVars in `__init__` with None-guards (verified unreachable; fallback matches config defaults); narrow `_config_callback` for the `after_idle` closure (verified never reassigned); explicit kwargs instead of `dict[str, object]` splats; migrate deprecated `ttkbootstrap.tooltip` import to `ttkbootstrap.widgets` (1.20.x)
- **utils**: fix genuinely broken `np.ndarray[any, ...]` annotations → `npt.NDArray[np.uint8]`; **real bug fix**: guard a `None.copy()` race in `Logger._update_log` when `_update_log` runs before `_update_stats`
- **tests**: `_RecordingLogger` subclasses the real `Logger` (verified side-effect-light: attributes + lock only)
- **cleanup**: drop the two stale `# pyright: ignore` pragmas in `utils/subprocess.py`

## Real bugs surfaced by ty

- `utils/logger.py` — `stats.copy()` crash window when `_update_log` ran before `_update_stats` (fixed here)
- `utils/image_handler.py` — annotations used builtin `any` in type position (fixed here)

No unresolved real bugs remain — every diagnostic was root-caused.

## Known cosmetic follow-ups (from review, intentionally not churned here)

- `ui.py` has two near-identical safe-int converters (`as_int`/`_safe_int`) — could merge
- `_compact_action_button_row` has two dead style branches for its two callers
- the hardcoded `"2"` StringVar fallbacks duplicate `config.py` defaults (currently unreachable)

## Test plan

- `make lint` (pre-commit incl. ty hook) green
- `uv run ty check` → exit 0, 5 warns (documented noise)
- `make test` → 16 passed
- `import pyclashbot.__main__` / `pyclashbot.interface.ui` verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

