### PR TITLE
ci: run PR checks regardless of base branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,6 @@ name: Pre-commit
 
 on:
   pull_request:
-    branches: [master]
   push:
     branches: [master]
 

--- a/.github/workflows/python-build-test.yml
+++ b/.github/workflows/python-build-test.yml
@@ -2,7 +2,6 @@ name: Build test packages
 
 on:
   pull_request:
-    branches: [master]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Motivation

Stacked PRs — PRs whose base branch is another feature branch rather than `master` — currently get **no CI checks**, because the `pull_request` triggers in our workflows are filtered with `branches: [master]`. #715 is a concrete example: it targeted a feature branch and ran zero checks.

## Changes

- **`.github/workflows/pre-commit.yml`**: removed `branches: [master]` from the `pull_request` trigger. The `push` trigger remains filtered to `master`.
- **`.github/workflows/python-build-test.yml`**: removed `branches: [master]` from its `pull_request` trigger.

Release/tag-triggered workflows (`python-build-release.yml`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)