### PR TITLE
docs(agents) + fix(setup): enforce pre-commit on commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Targets live in the `Makefile` (`make setup`/`dev`/`lint`/`test`/`type-check`, `
 - Persistent user settings go through `USER_SETTINGS_CACHE` (`pyclashbot.utils.caching`), keyed by `UIField.value` strings. Logging/stats go through `pyclashbot.utils.logger`; OS checks through `pyclashbot.utils.platform` (`is_windows()`/`is_macos()`).
 - Version is a `v0.0.0` placeholder in `pyproject.toml`; the real version is injected from the git tag at build time and read at runtime from `pyclashbot/__version__` via `utils/versioning.py`.
 - **Type checking is `ty`** (Astral), configured under `[tool.ty]` in `pyproject.toml` and enforced by pre-commit/CI; run it alone with `make type-check`. Suppress only genuine platform-gated false positives (Windows-only APIs), using `# ty: ignore[rule]` — never bare `# type: ignore`. A scoped override keeps ttkbootstrap's dynamic-kwarg noise in `interface/` at `warn`.
+- **Before committing, run `make lint`; never `git commit --no-verify`.** Pre-commit hooks aren't installed by default, so commits (especially from agents in fresh worktrees) silently skip the checks CI enforces. Run `make setup` once to install them — hooks live in the shared `.git/hooks`, so it covers every worktree.
 - Python 3.12 only. Conventional-commit messages.
 
 ## Where new code goes

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 setup:
 	uv sync
+	# pre-commit refuses to install while core.hooksPath is set; clear the stray
+	# (often worktree-set) value so hooks land in .git/hooks. `|| true` keeps it idempotent.
+	git config --unset-all core.hooksPath 2>/dev/null || true
 	uvx pre-commit install
 
 dev:


### PR DESCRIPTION
## What

1. **`AGENTS.md`** — adds a cross-cutting rule: run `make lint` before every commit, `make setup` once to install hooks, never `git commit --no-verify`.
2. **`Makefile`** — `setup` now unsets `core.hooksPath` before `pre-commit install`, so the install actually succeeds.

## Why

`uv sync` has no `postinstall`-style hook, and `.git/hooks/pre-commit` was never installed in this repo — so agent commits (especially from fresh worktrees) silently skipped the checks CI enforces.

`make setup` was *also* failing: pre-commit refuses to install while `core.hooksPath` is set (git would ignore `.git/hooks`), erroring with "Cowardly refusing to install hooks". A stray hooksPath value (pointing at the default location, likely worktree-set) triggered this. Clearing it first fixes the install; `|| true` keeps the target idempotent.

Together: the doc rule tells agents to run `make setup`, and this makes `make setup` work. Worktrees share the common `.git/hooks` via `core.hooksPath`, so installing once covers every worktree.

Verified `make setup` installs `pre-commit` + `commit-msg` hooks, exits 0, and reruns cleanly.