### PR TITLE
fix(memu): pass single string to logger.log in process-kill handler

### DIFF
--- a/pyclashbot/emulators/memu.py
+++ b/pyclashbot/emulators/memu.py
@@ -791,7 +791,7 @@ class MemuEmulatorController(BaseEmulatorController):
                     if proc.name() in name_list:
                         proc.kill()
                 except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
-                    self.logger.log("[!] Non-fatal error: Failed to kill process:", proc.name())
+                    self.logger.log(f"[!] Non-fatal error: Failed to kill process: {proc.name()}")
 
     def _skip_ads(self):
         """Skip ads in the emulator.


### PR DESCRIPTION
## What's the issue

In `pyclashbot/emulators/memu.py`, the residual-process kill handler called the logger with two positional arguments:

```python
self.logger.log("[!] Non-fatal error: Failed to kill process:", proc.name())
```

But `Logger.log(self, message)` (`pyclashbot/utils/logger.py:247`) accepts only one positional argument. When that branch executes, the call itself raises:

```
TypeError: Logger.log() takes 2 positional arguments but 3 were given
```

That exception escapes the `except (NoSuchProcess, AccessDenied, ZombieProcess)` block (it is a `TypeError`, not one of the caught psutil errors), bubbles up through the stop/restart sequence, and aborts the MEmu boot:

```
Failed to create MEmu emulator: Logger.log() takes 2 positional arguments but 3 were given
Failed to start MEmu. Verify its installation!
```

So a non-fatal "couldn't kill a leftover process" warning gets promoted into a hard boot failure.

## Who and when

Introduced in commit `20c347de` ("using ol' reliable emulator config technique + new logging for MEmu emulator configuration steps", #533) by Matt on 2025-09-09. It came in as part of that logging overhaul: the new log line was written `print`-style, splitting the message and the process name across two arguments instead of one formatted string.

## Why it is only surfacing now

The faulty line lives in the process-kill cleanup path, which only runs when a residual MEmu/ADB process actually fails to be killed (a `NoSuchProcess` / `AccessDenied` / `ZombieProcess` is raised during `proc.kill()`). On a clean machine that branch is rarely hit, so the call sat dormant for months. It only detonates when cleanup hits a stubborn leftover process, at which point the buggy logging call turns a recoverable hiccup into a failed boot.

## The fix

Collapse the two arguments into a single f-string so `log()` receives one message:

```python
self.logger.log(f"[!] Non-fatal error: Failed to kill process: {proc.name()}")
```

One-line change, no behavior change beyond the warning now logging correctly instead of throwing.
