### PR TITLE
feat(recorder): opt-in per-fight training-data capture (1v1 only)

### DIFF
--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -7,7 +7,6 @@ import logging
 import multiprocessing as mp
 import subprocess
 from multiprocessing import Queue
-from os.path import expandvars, join
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -52,7 +51,7 @@ from pyclashbot.utils.cli_config import arg_parser
 from pyclashbot.utils.discord_rpc import DiscordRPCManager
 from pyclashbot.utils.logger import Logger, initialize_pylogging, log_dir, log_name
 from pyclashbot.utils.open_folder import open_folder
-from pyclashbot.utils.platform import is_macos
+from pyclashbot.utils.platform import get_recordings_dir, is_macos
 
 initialize_pylogging()
 
@@ -261,8 +260,7 @@ def handle_process_finished(
 
 
 def open_recordings_folder() -> None:
-    folder_path = join(expandvars("%localappdata%"), "programs", "py-clash-bot", "recordings")
-    open_folder(folder_path)
+    open_folder(get_recordings_dir())
 
 
 def open_logs_folder() -> None:
@@ -278,6 +276,7 @@ class BotApplication:
         self.ui.main_btn.configure(command=self._on_main_button)
         self.ui.register_config_callback(self._on_config_change)
         self.ui.register_open_logs_callback(self._on_open_logs_clicked)
+        self.ui.register_open_recordings_callback(self._on_open_recordings_clicked)
         self.ui.protocol("WM_DELETE_WINDOW", self._on_close)
         self.ui.adb_refresh_btn.configure(command=self._on_adb_refresh)
         self.ui.adb_connect_btn.configure(command=self._on_adb_connect)
@@ -424,6 +423,9 @@ class BotApplication:
 
     def _on_open_logs_clicked(self) -> None:
         open_logs_folder()
+
+    def _on_open_recordings_clicked(self) -> None:
+        open_recordings_folder()
 
     def _on_close(self) -> None:
         self._closing = True

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -29,7 +29,12 @@ from pyclashbot.bot.nav import (
     wait_for_battle_start,
     wait_for_clash_main_menu,
 )
-from pyclashbot.bot.recorder import save_play, save_win_loss
+from pyclashbot.bot.recorder import (
+    finish_fight_recording,
+    is_recording,
+    log_play,
+    start_fight_recording,
+)
 from pyclashbot.bot.state_detect import (
     check_if_battle_has_ended,
     check_if_in_battle,
@@ -38,6 +43,7 @@ from pyclashbot.bot.state_detect import (
     count_elixir,
 )
 from pyclashbot.utils.logger import Logger
+from pyclashbot.utils.versioning import __version__
 
 ELIXIR_WAIT_TIMEOUT = 40  # too high but someone got errors with that so idk
 ABILITY_TRIGGER_DELAY_S = 3
@@ -59,6 +65,11 @@ def do_fight_state(
     if wait_for_battle_start(emulator, logger) is False:
         logger.change_status("Timed out waiting for battle to start")
         return False
+
+    # Opt-in training-data capture: 1v1-type fights only (Trophy Road / Classic 1v1), never 2v2.
+    if recording_flag and fight_mode_chosen in ["Classic 1v1", "Trophy Road"]:
+        pack_mode = "1v1_trophy" if fight_mode_chosen == "Trophy Road" else "1v1_classic"
+        start_fight_recording(emulator, pack_mode, __version__, logger=logger)
 
     logger.change_status("Starting fight loop")
     logger.log(f'This is the fight mode: "{fight_mode_chosen}"')
@@ -259,31 +270,35 @@ def end_fight_state(
     logger.log("Returning to main menu after fight")
     if get_to_main_after_fight(emulator, logger) is False:
         logger.log("Failed to return to main menu after fight")
+        finish_fight_recording(None)
         return False
 
     logger.log("Returned to main menu after fight")
     time.sleep(3)
 
-    # check if the prev game was a win
-    if not disable_win_tracker_toggle:
+    # Determine the outcome. Force the win check when a recording is active so the
+    # pack gets a real win/loss; otherwise honor the user's win-tracker toggle.
+    if is_recording() or not disable_win_tracker_toggle:
         win_check_return = check_if_previous_game_was_win(emulator, logger)
 
         if win_check_return == "restart":
             logger.log("Failed while checking if previous game was a win")
+            finish_fight_recording(None)
             return False
 
-        if win_check_return:
-            logger.add_win()
+        outcome = "win" if win_check_return else "loss"
 
-            if recording_flag:
-                save_win_loss("win")
-            return True
+        # Only touch the user's win/loss stats when their tracker is enabled.
+        if not disable_win_tracker_toggle:
+            if win_check_return:
+                logger.add_win()
+            else:
+                logger.add_loss()
 
-        logger.add_loss()
-        if recording_flag:
-            save_win_loss("loss")
+        finish_fight_recording(outcome)
     else:
         logger.log("Not checking win/loss because check is disabled")
+        finish_fight_recording(None)
 
     return True
 
@@ -402,7 +417,7 @@ def play_a_card(emulator, logger, recording_flag: bool, battle_strategy: "Battle
     emulator.click(play_coord[0], play_coord[1])
     click_and_play_card_time_taken = str(time.time() - click_and_play_card_start_time)[:3]
     if recording_flag:
-        save_play(play_coord, card_index)
+        log_play(card_index, play_coord[0], play_coord[1], card_id, battle_strategy.get_elapsed_time())
 
     logger.change_status(f"Made the play {click_and_play_card_time_taken}s")
     logger.add_card_played()

--- a/pyclashbot/bot/recorder.py
+++ b/pyclashbot/bot/recorder.py
@@ -1,264 +1,266 @@
-import csv
+"""Per-fight pack recorder for the opt-in "record training data" feature.
+
+Writes one self-contained folder per fight (the "pack" format consumed by the
+royalestrat ``user_data`` importer):
+
+    recordings/<slug>/
+      capture.mkv            # lossless FFV1 video, 419x633, BGR, 3 fps  (primary)
+       --- or, when FFV1 is unavailable on the user's machine: ---
+      frames/000000.png ...  # lossless PNG, 419x633, BGR, 3 fps         (fallback)
+      plays.jsonl            # one JSON line per actual card deploy
+      manifest.json
+
+Channel order is load-bearing: ``emulator.screenshot()`` is BGR and we keep it
+BGR end to end via cv2 (no PIL RGB flip). A fixed-cadence background thread grabs
+frames at ``fps`` while the worker thread logs the plays it makes inline.
+
+Only 1v1-type fights (Trophy Road, Classic 1v1) are recorded; 2v2 is never
+recorded (gated by the caller).
+"""
+
+from __future__ import annotations
+
 import json
 import os
+import secrets
+import threading
 import time
+from typing import Any
 
+import cv2
 import numpy as np
-from PIL import Image
 
-top_folder = r"recordings"
+from pyclashbot.utils.platform import get_recordings_dir
 
-
-def is_valid_play_input(play_coord, card_index):
-    coords_max_limit = 700
-    coords_low_limit = 0
-    card_indices = [0, 1, 2, 3]
-
-    if not isinstance(play_coord, tuple) or len(play_coord) != 2:
-        print("[!] Warning. Your play coordinates are not a tuple of two integers.")
-        return False
-
-    if not (coords_low_limit <= play_coord[0] <= coords_max_limit):
-        print(f"[!] Warning. Your play coordinates X are out of bounds: {play_coord[0]}")
-        return False
-
-    if not (coords_low_limit <= play_coord[1] <= coords_max_limit):
-        print(f"[!] Warning. Your play coordinates Y are out of bounds: {play_coord[1]}")
-        return False
-
-    if card_index not in card_indices:
-        print(f"[!] Warning. Your card index is not valid: {card_index}")
-        return False
-
-    return True
+# Fixed capture geometry (absolute emulator resolution). VideoWriter wants (w, h);
+# screenshots are (h, w, c) == (633, 419, 3).
+FRAME_W, FRAME_H = 419, 633
+DEFAULT_FPS = 3.0
+SCHEMA = "pcb-pack/v1"
 
 
-def save_play(play_coord, card_index):
-    os.makedirs(top_folder, exist_ok=True)
-
-    if not is_valid_play_input(play_coord, card_index):
-        return False
-
-    timestamp = int(time.time())
-    fp = f"{top_folder}/play_{timestamp}.json"
-    if os.path.exists(fp):
-        return False
-
-    data = {"play_coord": play_coord, "card_index": card_index}
-
-    with open(fp, "w") as f:
-        json.dump(data, f)
-    print("Saved a fight play to", fp)
-
-    return True
+def _new_slug() -> str:
+    """Slug = ``%Y%m%d-%H%M%S-<6 hex>`` (matches the rl-bot record format)."""
+    return time.strftime("%Y%m%d-%H%M%S", time.localtime()) + "-" + secrets.token_hex(3)
 
 
-def save_win_loss(result: str):
-    if type(result) is not str:
-        print("[!] Warning. Result must be a string.")
-        return False
+class FightPackRecorder:
+    """Captures one fight's frames + plays + outcome to a pack folder."""
 
-    valid_results = ["win", "loss"]
-    if result not in valid_results:
-        print(f"[!] Warning. Result must be one of {valid_results}.")
-        return False
+    def __init__(self, logger=None) -> None:
+        self.logger = logger
+        self.slug: str | None = None
+        self.dir: str | None = None
+        self.fps: float = DEFAULT_FPS
+        self.fight_mode: str = ""
+        self.version: str = ""
+        self.frames_source: str = "ffv1"
 
-    os.makedirs(top_folder, exist_ok=True)
-    timestamp = int(time.time())
-    fp = f"{top_folder}/result_{timestamp}.txt"
-    if os.path.exists(fp):
-        return False
-    print("Saved a fight result to", fp)
-    with open(fp, "w") as f:
-        f.write(result)
+        self._emulator: Any = None
+        self._writer: cv2.VideoWriter | None = None
+        self._frames_dir: str | None = None
+        self._frame_count: int = 0
+        self._plays: list[dict] = []
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started_wall: float = 0.0
 
+    # ---- lifecycle ------------------------------------------------------
 
-def save_image(image: np.ndarray):
-    print("Saving a fight image")
-    os.makedirs(top_folder, exist_ok=True)
+    def start(self, emulator, fight_mode: str, version: str, fps: float = DEFAULT_FPS) -> bool:
+        """Begin capturing. Returns True on success (a frame thread is running)."""
+        self.slug = _new_slug()
+        self.dir = os.path.join(get_recordings_dir(), self.slug)
+        self.fps = fps
+        self.fight_mode = fight_mode
+        self.version = version
+        self._emulator = emulator
+        self._frame_count = 0
+        self._plays = []
+        self._stop.clear()
+        self._started_wall = time.time()
 
-    timestamp = int(time.time())
-    fp = f"{top_folder}/fight_image_{timestamp}.png"
-    if os.path.exists(fp):
-        print(f"[!] Warning. Fight image file {fp} already exists.")
-        return False
+        os.makedirs(self.dir, exist_ok=True)
+        self.frames_source = self._open_encoder()
 
-    # Convert BGR (OpenCV) to RGB (PIL)
-    rgb_image = image[..., ::-1]
-    pil_image = Image.fromarray(rgb_image)
-    pil_image.save(fp)
-    print("Saved a fight image to", fp)
-    return True
+        self._thread = threading.Thread(target=self._capture_loop, name="fight-capture", daemon=True)
+        self._thread.start()
+        self._log(f"Started fight recording {self.slug} (source={self.frames_source}, fps={fps})")
+        return True
 
+    def log_play(self, slot: int, x: int, y: int, card_id: str, elapsed_s: float) -> None:
+        """Record one card deploy, pairing it to the current frame index."""
+        if self.dir is None:
+            return
+        entry = {
+            "frame_index": self._frame_count,  # atomic int read under the GIL
+            "slot": int(slot),
+            "x": int(x),
+            "y": int(y),
+            "card_id": str(card_id) if card_id else "UNKNOWN",
+            "elapsed_s": round(float(elapsed_s), 2),
+        }
+        with self._lock:
+            self._plays.append(entry)
 
-def to_csv():
-    header = ["image_file", "play_coord_x", "play_coord_y", "card_index", "result"]
-    rows = []
-
-    files = os.listdir(top_folder)
-    remaining_image_files = [f for f in files if f.startswith("fight_image_") and f.endswith(".png")]
-    remaining_play_files = [f for f in files if f.startswith("play_") and f.endswith(".json")]
-    result_files = [f for f in files if f.startswith("result_") and f.endswith(".txt")]
-
-    # go fight by fight
-    results_timestamps = []
-    for results_file in result_files:
-        result_timestamp = results_file.split("_")[1].split(".")[0]
-        results_timestamps.append(result_timestamp)
-
-    def get_image_files_before_timestamp(timestamp, range_length: int):
-        files = [f for f in remaining_image_files if int(f.split("_")[2].split(".")[0]) <= int(timestamp)]
-        return [f for f in files if int(f.split("_")[2].split(".")[0]) > int(timestamp) - range_length]
-
-    def get_play_files_before_timestamp(timestamp, range_length: int):
-        files = [f for f in remaining_play_files if int(f.split("_")[1].split(".")[0]) <= int(timestamp)]
-        return [f for f in files if int(f.split("_")[1].split(".")[0]) > int(timestamp) - range_length]
-
-    def extract_timestamp_from_filename(file_name):
-        # fight_image_1754003855.png
-        # play_1754004137.json
-        # result_1754004114.txt
-        try:
-            parts = file_name.split("_")
-            if len(parts) < 1:
-                return None
-            timestamp_part = parts[-1].split(".")[0]
-            return int(timestamp_part)
-        except Exception as e:
-            print(f"[!] Warning! Could not extract timestamp from file name {file_name}: {e}")
+    def finish(self, outcome: str | None) -> str | None:
+        """Stop capture, finalize the video/frames, and write the metadata."""
+        if self.dir is None:
             return None
 
-    def find_images_in_range(play_timestamp, range_length: int, image_file_names):
-        cutoff = play_timestamp - range_length
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+        if self._writer is not None:
+            self._writer.release()
+            self._writer = None
 
-        timestamp2image_name = {}
-        for image_file_name in image_file_names:
-            image_timestamp = extract_timestamp_from_filename(image_file_name)
+        ended_wall = time.time()
+        self._write_plays()
+        self._write_manifest(outcome, ended_wall)
+        self._log(f"Finished fight recording {self.slug}: {self._frame_count} frames, {len(self._plays)} plays")
+        return self.slug
 
-            if image_timestamp is None:
-                continue
+    # ---- internals ------------------------------------------------------
 
-            if image_timestamp > cutoff and image_timestamp < play_timestamp:
-                timestamp2image_name[image_timestamp] = image_file_name
-            #     print('This image timestamp is in range:', image_timestamp, 'of this target_timestamp:', play_timestamp)
-            # else:
-            #     print('This image timestamp is out of range:', image_timestamp, 'from this target_timestamp:', play_timestamp)
-
-        # sort the dict by timestamp
-        sorted_timestamp2image_name = dict(sorted(timestamp2image_name.items(), key=lambda item: item[0]))
-
-        # return the image names
-        return list(sorted_timestamp2image_name.values())
-
-    def find_no_play_images(image_files, play_files, buffer_seconds=6):
-        no_play_image_files = []
-
-        for image_file in image_files:
-            image_timestamp = extract_timestamp_from_filename(image_file)
-            if image_timestamp is None:
-                continue
-
-            close_to_play = False
-            for play_file in play_files:
-                play_timestamp = extract_timestamp_from_filename(play_file)
-                if play_timestamp is None:
-                    continue
-
-                if abs(image_timestamp - play_timestamp) < buffer_seconds:
-                    close_to_play = True
-                    continue
-
-            if not close_to_play:
-                no_play_image_files.append(image_file)
-
-        return no_play_image_files
-
-    def timestamp2results_file(timestmap):
-        fp = f"{top_folder}/result_{timestmap}.txt"
-        if os.path.exists(fp):
-            return fp
-
-    def read_result(results_file):
-        with open(results_file) as f:
-            result = f.read().strip()
-            return result
-
-    # go results file by results file
-    # mapping each image and play to the result
-    play_rows_added = 0
-    no_play_rows_added = 0
-    results_timestamps = sorted(set(results_timestamps))
-    for result_timestamp in results_timestamps:
-        results_file = timestamp2results_file(result_timestamp)
-        result = read_result(results_file)
-
-        # grab the ones in range
-        images = get_image_files_before_timestamp(result_timestamp, range_length=400)
-        plays = get_play_files_before_timestamp(result_timestamp, range_length=400)
-
-        print(f"This results timestamp: {result_timestamp}")
-        print(f"\t-Has {len(images)} images and {len(plays)} plays")
-
-        # delete them from the lists
-        for image in images:
-            remaining_image_files.remove(image)
-        for play in plays:
-            remaining_play_files.remove(play)
-
-        # extract the plays where a play was made
-        for play in plays:
-            play_timestamp = extract_timestamp_from_filename(play)
-            file_names = find_images_in_range(play_timestamp, 3, images)
-            if not file_names:
-                print(f"\t-Found no images for this play timestamp: {play_timestamp}")
-                continue
-            most_recent_image = file_names[-1]
-            print(f"\tPlay: {play}, Most Recent Image: {most_recent_image}")
-            play_data = json.load(open(f"{top_folder}/{play}"))
-            print(f"Play play_coord: {play_data['play_coord']}")
-            print("Type of play data[play_coord]:", type(play_data["play_coord"]))
-            row = [
-                most_recent_image,
-                play_data["play_coord"][0],
-                play_data["play_coord"][1],
-                play_data["card_index"],
-                result,
-            ]
-            rows.append(row)
-            play_rows_added += 1
-
-        no_play_images = find_no_play_images(images, plays, buffer_seconds=5)
-        for no_play_image in no_play_images:
-            print(
-                f"\tNo play: Image found in results ts: {result_timestamp}:",
-                no_play_image,
+    def _open_encoder(self) -> str:
+        """Probe FFV1; return 'ffv1' (and open self._writer) or 'png' (frames dir)."""
+        assert self.dir is not None
+        if self._ffv1_available():
+            self._writer = cv2.VideoWriter(
+                os.path.join(self.dir, "capture.mkv"),
+                cv2.VideoWriter.fourcc(*"FFV1"),
+                self.fps,
+                (FRAME_W, FRAME_H),
             )
-            row = [
-                no_play_image,
-                None,  # No play coordinates
-                None,  # No card index
-                None,  # No card index
-                result,
-            ]
-            rows.append(row)
-            no_play_rows_added += 1
+            if self._writer.isOpened():
+                return "ffv1"
+            self._writer = None
 
-    print("\n---CSV Stats---")
-    print(f"\t-Created a total of {len(rows)} rows")
-    print(f"\t-Created a total of {play_rows_added} play rows")
-    print(f"\t-Created a total of {no_play_rows_added} no play images")
-    print(f"\t-Using {len(results_timestamps)} results files")
+        # Fallback: lossless PNG frames.
+        self._frames_dir = os.path.join(self.dir, "frames")
+        os.makedirs(self._frames_dir, exist_ok=True)
+        return "png"
 
-    csv_extraction_path = r"recordings/recordings.csv"
+    def _ffv1_available(self) -> bool:
+        """One-time codec probe: write a throwaway FFV1 frame and read it back."""
+        assert self.dir is not None
+        probe = os.path.join(self.dir, "_probe.mkv")
+        try:
+            writer = cv2.VideoWriter(probe, cv2.VideoWriter.fourcc(*"FFV1"), self.fps, (FRAME_W, FRAME_H))
+            if not writer.isOpened():
+                writer.release()
+                return False
+            writer.write(np.zeros((FRAME_H, FRAME_W, 3), dtype=np.uint8))
+            writer.release()
+            cap = cv2.VideoCapture(probe)
+            ok, _ = cap.read()
+            cap.release()
+            return bool(ok)
+        except Exception as e:
+            self._log(f"FFV1 probe failed, falling back to PNG frames: {e}")
+            return False
+        finally:
+            if os.path.exists(probe):
+                try:
+                    os.remove(probe)
+                except OSError:
+                    pass
 
-    with open(csv_extraction_path, "w", newline="") as csvfile:
-        writer = csv.writer(csvfile)
-        writer.writerow(header)
-        writer.writerows(rows)
+    def _capture_loop(self) -> None:
+        interval = 1.0 / self.fps
+        next_t = time.time()
+        while not self._stop.is_set():
+            try:
+                frame = self._emulator.screenshot()
+            except Exception as e:
+                self._log(f"Capture screenshot failed: {e}")
+                frame = None
+            if frame is not None and frame.shape == (FRAME_H, FRAME_W, 3):
+                self._write_frame(frame)
+                self._frame_count += 1
+            next_t += interval
+            delay = next_t - time.time()
+            if delay > 0:
+                self._stop.wait(delay)
+            else:
+                next_t = time.time()  # behind schedule; resync
 
-    print(f"\t-Created the csv file at {csv_extraction_path}")
+    def _write_frame(self, frame: np.ndarray) -> None:
+        if self.frames_source == "ffv1" and self._writer is not None:
+            self._writer.write(frame)  # BGR in, BGR out
+        elif self._frames_dir is not None:
+            cv2.imwrite(os.path.join(self._frames_dir, f"{self._frame_count:06d}.png"), frame)
+
+    def _write_plays(self) -> None:
+        assert self.dir is not None
+        with self._lock, open(os.path.join(self.dir, "plays.jsonl"), "w", encoding="utf-8") as f:
+            for entry in self._plays:
+                f.write(json.dumps(entry) + "\n")
+
+    def _write_manifest(self, outcome: str | None, ended_wall: float) -> None:
+        assert self.dir is not None
+        manifest = {
+            "schema": SCHEMA,
+            "slug": self.slug,
+            "outcome": outcome,
+            "fight_mode": self.fight_mode,
+            "fps": self.fps,
+            "resolution": [FRAME_W, FRAME_H],
+            "frames_source": self.frames_source,
+            "n_frames": self._frame_count,
+            "n_plays": len(self._plays),
+            "pcb_version": self.version,
+            "started_wall": self._started_wall,
+            "ended_wall": ended_wall,
+        }
+        with open(os.path.join(self.dir, "manifest.json"), "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2)
+
+    def _log(self, message: str) -> None:
+        if self.logger is not None:
+            self.logger.log(message)
+        else:
+            print(message)
 
 
-if __name__ == "__main__":
-    print("\n" * 50)
-    to_csv()
+# ---- module-level active-recorder singleton -----------------------------
+# The fight lifecycle spans separate state functions (do_fight_state ->
+# play_a_card -> end_fight_state) inside the single worker process, so the
+# active recorder is held here and driven through thin module functions.
+
+_active: FightPackRecorder | None = None
+
+
+def start_fight_recording(emulator, fight_mode: str, version: str, logger=None, fps: float = DEFAULT_FPS) -> None:
+    global _active
+    finish_fight_recording(None)  # defensively close any stale recorder
+    recorder = FightPackRecorder(logger=logger)
+    try:
+        recorder.start(emulator, fight_mode, version, fps=fps)
+        _active = recorder
+    except Exception as e:
+        if logger is not None:
+            logger.log(f"Failed to start fight recording: {e}")
+        else:
+            print(f"Failed to start fight recording: {e}")
+        _active = None
+
+
+def log_play(slot: int, x: int, y: int, card_id: str, elapsed_s: float) -> None:
+    if _active is not None:
+        _active.log_play(slot, x, y, card_id, elapsed_s)
+
+
+def finish_fight_recording(outcome: str | None) -> None:
+    global _active
+    if _active is not None:
+        try:
+            _active.finish(outcome)
+        finally:
+            _active = None
+
+
+def is_recording() -> bool:
+    return _active is not None

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -509,7 +509,7 @@ def state_tree(
 
         random_plays_flag = job_list.get(UIField.RANDOM_PLAYS_USER_TOGGLE, False)
 
-        recording_flag = job_list.get(UIField.RECORD_FIGHTS_TOGGLE, False)
+        # 2v2 fights are never recorded (training data is 1v1-only: Trophy Road + Classic 1v1).
         if (
             do_fight_state(
                 emulator,
@@ -517,7 +517,7 @@ def state_tree(
                 random_plays_flag,
                 "Classic 2v2",
                 called_from_launching=False,
-                recording_flag=recording_flag,
+                recording_flag=False,
             )
             is False
         ):

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -144,9 +144,11 @@ class PyClashBotUI(ttk.Window):
             current_theme = self.DEFAULT_THEME
         self.theme_var = ttk.StringVar(value=current_theme)
         self.discord_rpc_var = ttk.BooleanVar(value=False)
+        self.record_fights_var = ttk.BooleanVar(value=False)
         self.advanced_settings_var = ttk.BooleanVar(value=False)
         self._config_callback: Callable[[dict[str, object]], None] | None = None
         self._open_logs_callback: Callable[[], None] | None = None
+        self._open_recordings_callback: Callable[[], None] | None = None
         self._config_widgets: dict[str, tk.Widget] = {}
         self._job_toggle_checkbuttons: dict[UIField, ttk.Checkbutton] = {}
         self._job_row_extras: dict[UIField, list[tk.Widget]] = {}
@@ -175,6 +177,9 @@ class PyClashBotUI(ttk.Window):
 
     def register_open_logs_callback(self, callback: Callable[[], None]) -> None:
         self._open_logs_callback = callback
+
+    def register_open_recordings_callback(self, callback: Callable[[], None]) -> None:
+        self._open_recordings_callback = callback
 
     def get_all_values(self) -> dict[str, object]:
         values: dict[str, object] = {}
@@ -221,6 +226,7 @@ class PyClashBotUI(ttk.Window):
 
         values[UIField.THEME_NAME.value] = self.theme_var.get() or self.DEFAULT_THEME
         values[UIField.DISCORD_RPC_TOGGLE.value] = bool(self.discord_rpc_var.get())
+        values[UIField.RECORD_FIGHTS_TOGGLE.value] = bool(self.record_fights_var.get())
         return values
 
     def set_all_values(self, values: dict[str, object]) -> None:
@@ -311,6 +317,9 @@ class PyClashBotUI(ttk.Window):
 
         if UIField.DISCORD_RPC_TOGGLE.value in values:
             self.discord_rpc_var.set(bool(values[UIField.DISCORD_RPC_TOGGLE.value]))
+
+        if UIField.RECORD_FIGHTS_TOGGLE.value in values:
+            self.record_fights_var.set(bool(values[UIField.RECORD_FIGHTS_TOGGLE.value]))
 
         self._show_current_emulator_settings()
 
@@ -1165,12 +1174,28 @@ class PyClashBotUI(ttk.Window):
         self._trace_variable(self.discord_rpc_var)
         self._register_config_widget(UIField.DISCORD_RPC_TOGGLE.value, discord_checkbox)
 
-        (self.open_logs_btn,) = self._compact_action_button_row(
+        record_fights_checkbox = ttk.Checkbutton(
+            data_frame,
+            text="Record my 1v1 fights as training data (saved locally to share with the developer)",
+            variable=self.record_fights_var,
+            bootstyle="round-toggle",
+            command=self._notify_config_change,
+        )
+        record_fights_checkbox.pack(anchor="w", pady=(0, 6))
+        self._trace_variable(self.record_fights_var)
+        self._register_config_widget(UIField.RECORD_FIGHTS_TOGGLE.value, record_fights_checkbox)
+
+        self.open_logs_btn, self.open_recordings_btn = self._compact_action_button_row(
             data_frame,
             {
                 "text": "Open logs folder",
                 "bootstyle": "secondary",
                 "command": self._on_open_logs_clicked,
+            },
+            {
+                "text": "Browse recorded games",
+                "bootstyle": "secondary",
+                "command": self._on_open_recordings_clicked,
             },
         )
 
@@ -1445,6 +1470,10 @@ class PyClashBotUI(ttk.Window):
     def _on_open_logs_clicked(self) -> None:
         if self._open_logs_callback:
             self._open_logs_callback()
+
+    def _on_open_recordings_clicked(self) -> None:
+        if self._open_recordings_callback:
+            self._open_recordings_callback()
 
     def _update_advanced_settings_visibility(self, emulator_choice: str) -> None:
         show_advanced = bool(self.advanced_settings_var.get())

--- a/pyclashbot/utils/platform.py
+++ b/pyclashbot/utils/platform.py
@@ -42,6 +42,11 @@ def get_log_dir(app_name: str) -> str:
     return os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), app_name, "logs")
 
 
+def get_recordings_dir(app_name: str = "py-clash-bot") -> str:
+    """Return the single source-of-truth directory for recorded fight packs."""
+    return os.path.join(get_app_data_dir(app_name), "recordings")
+
+
 def is_windows() -> bool:
     """Check if running on Windows."""
     return get_platform() == Platform.WINDOWS

--- a/tests/test_fight_pack_recorder.py
+++ b/tests/test_fight_pack_recorder.py
@@ -1,0 +1,92 @@
+"""Offline tests for the per-fight pack recorder (no emulator).
+
+Drives FightPackRecorder over a fake screenshot() source and asserts the
+written pack matches the shared pack format, including the FFV1 -> PNG fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import numpy as np
+
+from pyclashbot.bot import recorder as rec
+from pyclashbot.bot.recorder import FightPackRecorder
+
+
+class _FakeEmu:
+    """Returns a valid (633, 419, 3) BGR frame on every screenshot()."""
+
+    def screenshot(self) -> np.ndarray:
+        return np.zeros((633, 419, 3), dtype=np.uint8)
+
+
+def _read_manifest(pack_dir: str) -> dict:
+    with open(os.path.join(pack_dir, "manifest.json"), encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _drive_one_fight(recorder: FightPackRecorder, *, fps: float = 20.0) -> str:
+    recorder.start(_FakeEmu(), "1v1_trophy", "vTEST", fps=fps)
+    recorder.log_play(2, 215, 360, "hog_rider", 47.3)
+    time.sleep(0.5)  # let the capture thread grab several frames
+    slug = recorder.finish("win")
+    assert slug is not None
+    return os.path.join(rec.get_recordings_dir(), slug)
+
+
+def test_pack_is_spec_valid(tmp_path, monkeypatch):
+    monkeypatch.setattr(rec, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+
+    recorder = FightPackRecorder()
+    pack_dir = _drive_one_fight(recorder)
+
+    manifest = _read_manifest(pack_dir)
+    assert manifest["schema"] == "pcb-pack/v1"
+    assert manifest["resolution"] == [419, 633]
+    assert manifest["fight_mode"] == "1v1_trophy"
+    assert manifest["outcome"] == "win"
+    assert manifest["pcb_version"] == "vTEST"
+    assert manifest["frames_source"] in ("ffv1", "png")
+    assert manifest["n_frames"] >= 1
+    assert manifest["n_plays"] == 1
+
+    # plays.jsonl: one valid line, frame_index within range.
+    with open(os.path.join(pack_dir, "plays.jsonl"), encoding="utf-8") as f:
+        plays = [json.loads(line) for line in f if line.strip()]
+    assert len(plays) == 1
+    play = plays[0]
+    assert play["slot"] == 2 and play["x"] == 215 and play["y"] == 360
+    assert play["card_id"] == "hog_rider"
+    assert 0 <= play["frame_index"] <= manifest["n_frames"]
+
+
+def test_png_fallback_when_ffv1_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(rec, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+    # Force the codec probe to fail so the PNG fallback path is exercised.
+    monkeypatch.setattr(FightPackRecorder, "_ffv1_available", lambda self: False)
+
+    recorder = FightPackRecorder()
+    pack_dir = _drive_one_fight(recorder)
+
+    manifest = _read_manifest(pack_dir)
+    assert manifest["frames_source"] == "png"
+
+    frames_dir = os.path.join(pack_dir, "frames")
+    pngs = sorted(p for p in os.listdir(frames_dir) if p.endswith(".png"))
+    assert len(pngs) == manifest["n_frames"]
+    assert not os.path.exists(os.path.join(pack_dir, "capture.mkv"))
+
+
+def test_module_singleton_helpers(tmp_path, monkeypatch):
+    monkeypatch.setattr(rec, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+
+    assert rec.is_recording() is False
+    rec.start_fight_recording(_FakeEmu(), "1v1_classic", "vTEST")
+    assert rec.is_recording() is True
+    rec.log_play(0, 100, 200, "UNKNOWN", 1.0)
+    time.sleep(0.3)
+    rec.finish_fight_recording("loss")
+    assert rec.is_recording() is False


### PR DESCRIPTION
## What this does

Implements the **py-clash-bot side** of the crowdsourced fight-data pipeline (`royalestrat/docs/crowdsourced-fight-data-pipeline.md`, Section 4). Adds an **opt-in** "record training data" feature: when enabled, each 1v1-type fight is captured to a self-contained per-fight folder (the "pack") that the dev's `user_data` importer reconstructs into training data by running the local vision models. The vision models never leave the dev machine.

### Scope constraint
Records **Trophy Road and Classic 1v1 only**. **2v2 is never recorded** (the recording path is gated to the `1v1_fight` state and forced off on the `2v2_fight` path).

### Pack format (per fight, in `%APPDATA%/py-clash-bot/recordings/<slug>/`)
- `capture.mkv` (lossless FFV1, 419x633, BGR, 3 fps) or `frames/NNNNNN.png` fallback when FFV1 is unavailable
- `plays.jsonl` (one line per card deploy: frame_index, slot, x, y, card_id, elapsed_s)
- `manifest.json` (schema `pcb-pack/v1`, outcome, fight_mode, fps, resolution, frames_source, counts, pcb_version, wall times)

Channel order is kept **BGR end to end** via cv2 (no PIL RGB flip), matching what the live collector feeds the models.

### Changes
- **`bot/recorder.py`**: rewritten from the dormant CSV scaffold into `FightPackRecorder` (fixed-cadence BGR capture thread, FFV1 codec probe with PNG fallback, plays/manifest writers) plus module-level `start_fight_recording` / `log_play` / `finish_fight_recording` / `is_recording` helpers.
- **`bot/fight.py`**: start capture after battle start (1v1 modes only), log each real deploy with `card_id` + elapsed time, and on end force the win check when recording so the pack gets a real outcome (without polluting the user's win stats if their tracker is off).
- **`bot/states.py`**: 2v2 fight path passes `recording_flag=False`.
- **`utils/platform.py`**: `get_recordings_dir()` single source of truth (app-data `recordings/`).
- **`interface/ui.py` + `__main__.py`**: consent checkbox in the Misc/Data tab and a "Browse recorded games" button; `open_recordings_folder()` now uses the unified dir.

### Verification
- New offline tests (`tests/test_fight_pack_recorder.py`): a spec-valid pack is written over fake frames; the FFV1-to-PNG fallback triggers when the codec is forced unavailable; the module singleton helpers round-trip. All pass.
- Full offline suite green (25 passed); `ruff` clean on all changed files; `ty` adds zero new diagnostics over baseline.
- No new dependencies (cv2 / numpy / pillow already present).

### Notes / for validation
- The capture thread adds ~3 screencaps/sec on top of the bot's own detection screencaps (acceptable for an opt-in feature; noted in the design).
- End-to-end validation (record a real 1v1, decode the pack on the dev side) is the home-side step in Section 5.
