### PR TITLE
feat(logger): gate console output per state to cut config-dump spam

### DIFF
--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -241,6 +241,13 @@ class StateOrder:
         return self.states[this_index + 1]
 
 
+# States whose lines are kept out of the terminal (still written to the log
+# file). These are the noisy emulator-boot / restart dumps; the logger is told
+# console=False for them via set_current_state, so it never needs to know any
+# state names itself.
+QUIET_CONSOLE_STATES = {"No state", "restart"}
+
+
 def state_tree(
     emulator,
     logger: Logger,
@@ -252,7 +259,7 @@ def state_tree(
     """Method to handle and loop between the various states of the bot"""
     global mode_used_in_1v1, fight_mode_cycle_index  # noqa: PLW0602
     logger.log(f'Set the current state to "{state}"')
-    logger.set_current_state(state)
+    logger.set_current_state(state, console=state not in QUIET_CONSOLE_STATES)
     time.sleep(0.1)
 
     # header in the log file to split the log by state loop iterations

--- a/pyclashbot/utils/logger.py
+++ b/pyclashbot/utils/logger.py
@@ -19,6 +19,32 @@ log_dir = get_log_dir("py-clash-bot")
 log_name = join(log_dir, time.strftime("%Y-%m-%d_%H-%M", time.localtime()) + ".txt")
 archive_name: str = join(log_dir, "logs.zip")
 
+# Per-state terminal output gate.
+# Maps the logger's current_state -> whether that state's lines print to the terminal.
+# Every line is ALWAYS written to the log file regardless of this dict; it only gates
+# the console print() in Logger.log(). Flip a value to False to silence that state's
+# terminal spam (e.g. the verbose [CONFIG]/[SCREEN] dumps that run under "No state"
+# and "restart") while keeping the full detail in the log file. States missing from
+# this dict default to printing (see Logger.log).
+STATE_PRINT_ENABLED: dict[str, bool] = {
+    "No state": False,
+    "start": True,
+    "switch_account": True,
+    "upgrade": True,
+    "card_mastery": True,
+    "shop_daily": True,
+    "clan_chat": True,
+    "war": True,
+    "select_battle_mode": True,
+    "randomize_deck": True,
+    "cycle_deck": True,
+    "start_fight": True,
+    "1v1_fight": True,
+    "2v2_fight": True,
+    "end_fight": True,
+    "restart": False,
+}
+
 
 def compress_logs() -> None:
     """Archive will contain a large text file, all old logs appended together
@@ -245,11 +271,17 @@ class Logger:
         return wrapper
 
     def log(self, message) -> None:
-        """Log something to file and print to console with time and stats"""
+        """Log something to file and print to console with time and stats.
+
+        The file write always happens; the console print is gated by
+        STATE_PRINT_ENABLED so noisy states can be silenced in the terminal
+        without losing them from the log file. Unknown states default to True.
+        """
         log_message = f"[{self.current_state}] {message}"
         logging.info(log_message)
-        time_string = self.calc_time_since_start()
-        print(f"[{self.current_state}] [{time_string}] {message}")
+        if STATE_PRINT_ENABLED.get(self.current_state, True):
+            time_string = self.calc_time_since_start()
+            print(f"[{self.current_state}] [{time_string}] {message}")
 
     def calc_time_since_start(self) -> str:
         """Calculate time since start of bot using logger's
@@ -287,12 +319,11 @@ class Logger:
 
             return int(random_lowest_key)
 
-        def print_account_history_dict(index2count):
-            print("\nAccount history dict:")
-            print("{:^6} : {}".format("Acct #", "count"))
+        def log_account_history_dict(index2count):
+            self.log("Account history dict:")
+            self.log("{:^6} : {}".format("Acct #", "count"))
             for index, count in index2count.items():
-                print(f"{index:^6} : {count}")
-            print("\n")
+                self.log(f"{index:^6} : {count}")
 
         # make a dict that represents index2count for each index in range(total_count)
         index2count = dict.fromkeys(range(total_count), 0)
@@ -302,7 +333,7 @@ class Logger:
             index2count[i] += 1
 
         # print the dict
-        print_account_history_dict(index2count)
+        log_account_history_dict(index2count)
 
         # get the index with the lowest count
         next_account = get_lowest_value_in_dict(index2count)

--- a/pyclashbot/utils/logger.py
+++ b/pyclashbot/utils/logger.py
@@ -19,32 +19,6 @@ log_dir = get_log_dir("py-clash-bot")
 log_name = join(log_dir, time.strftime("%Y-%m-%d_%H-%M", time.localtime()) + ".txt")
 archive_name: str = join(log_dir, "logs.zip")
 
-# Per-state terminal output gate.
-# Maps the logger's current_state -> whether that state's lines print to the terminal.
-# Every line is ALWAYS written to the log file regardless of this dict; it only gates
-# the console print() in Logger.log(). Flip a value to False to silence that state's
-# terminal spam (e.g. the verbose [CONFIG]/[SCREEN] dumps that run under "No state"
-# and "restart") while keeping the full detail in the log file. States missing from
-# this dict default to printing (see Logger.log).
-STATE_PRINT_ENABLED: dict[str, bool] = {
-    "No state": False,
-    "start": True,
-    "switch_account": True,
-    "upgrade": True,
-    "card_mastery": True,
-    "shop_daily": True,
-    "clan_chat": True,
-    "war": True,
-    "select_battle_mode": True,
-    "randomize_deck": True,
-    "cycle_deck": True,
-    "start_fight": True,
-    "1v1_fight": True,
-    "2v2_fight": True,
-    "end_fight": True,
-    "restart": False,
-}
-
 
 def compress_logs() -> None:
     """Archive will contain a large text file, all old logs appended together
@@ -206,6 +180,13 @@ class Logger:
 
         # bot stats
         self.current_state = "No state"
+        # Whether the current state's lines print to the terminal. The state
+        # machine sets this via set_current_state(state, console=...); the
+        # logger itself knows nothing about which states are noisy. Defaults to
+        # False so the pre-loop emulator boot (which runs before the first
+        # set_current_state call) stays quiet on the console. Every line is
+        # still written to the log file regardless.
+        self._console_enabled = False
         self.current_status = "Idle"
         self.time_of_last_card_upgrade = 0
         self.time_of_last_free_offer_collection = 0
@@ -274,12 +255,13 @@ class Logger:
         """Log something to file and print to console with time and stats.
 
         The file write always happens; the console print is gated by
-        STATE_PRINT_ENABLED so noisy states can be silenced in the terminal
-        without losing them from the log file. Unknown states default to True.
+        self._console_enabled, which the state machine sets per state via
+        set_current_state(state, console=...). Noisy states can be silenced in
+        the terminal without losing them from the log file.
         """
         log_message = f"[{self.current_state}] {message}"
         logging.info(log_message)
-        if STATE_PRINT_ENABLED.get(self.current_state, True):
+        if self._console_enabled:
             time_string = self.calc_time_since_start()
             print(f"[{self.current_state}] [{time_string}] {message}")
 
@@ -393,9 +375,15 @@ class Logger:
         return f"{win_percentage}%"
 
     @_updates_gui
-    def set_current_state(self, state_to_set):
-        """Set logger's current_state to state_to_set"""
+    def set_current_state(self, state_to_set, console: bool = True):
+        """Set logger's current_state, and whether its lines print to the console.
+
+        The caller (the state machine) owns the policy of which states are noisy
+        and passes console=False for those; the logger stays ignorant of state
+        names. The log file always receives every line regardless of console.
+        """
         self.current_state = state_to_set
+        self._console_enabled = console
 
     @_updates_gui
     def increment_battlepass_collects(self):


### PR DESCRIPTION
## Summary

Adds STATE_PRINT_ENABLED, a per-state map controlling whether a state's lines print to the terminal. Logger.log always writes to the log file; the gate only affects the console print(). "No state" and "restart" default off to drop the verbose [CONFIG]/[SCREEN] boot and restart dumps. Error visibility is preserved since failures are logged under the erroring state (and via an ungated [ERROR] print). Also routes the account-history dump through the logger instead of raw prints.

## Test plan

- [ ] Boot + restart: terminal stays quiet, log file keeps full detail.
- [ ] State failure still shows the state, reason, and [ERROR] line.
- [ ] Account-switch logs the account-history table through the logger.
