### PR TITLE
feat(recorder): skip recording at >90% disk; add clear-recordings button

### DIFF
--- a/.github/workflows/python-build-release.yml
+++ b/.github/workflows/python-build-release.yml
@@ -62,6 +62,9 @@ jobs:
             ./dist/py-clash-bot*.dmg
 
   notify:
+    # Skippable for silent re-tags/hotswaps: set the repo variable
+    # ANNOUNCE_DISCORD to 'false' to suppress the release ping, then restore it.
+    if: ${{ vars.ANNOUNCE_DISCORD != 'false' }}
     name: Send Discord notification
     needs: [build-windows, build-macos]
     runs-on: ubuntu-latest

--- a/pyclashbot/bot/recorder.py
+++ b/pyclashbot/bot/recorder.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import secrets
+import shutil
 import threading
 import time
 import uuid
@@ -42,6 +43,11 @@ from pyclashbot.utils.platform import get_recordings_dir
 # screenshots are (h, w, c) == (633, 419, 3).
 FRAME_W, FRAME_H = 419, 633
 DEFAULT_FPS = 3.0
+# Skip starting a new recording once the recordings drive is over 90% full
+# (free space below this fraction of total). Never deletes anything -- it just
+# stops adding to a nearly-full disk. Manual cleanup is the "Clear recordings"
+# button in the interface.
+MIN_FREE_DISK_FRACTION = 0.10
 SCHEMA = "pcb-pack/v1"
 # Max per-channel deviation tolerated on the FFV1 round-trip probe. Lossless RGB
 # (gbrp) round-trips bit-exact; yuv444p adds a few counts of matrix rounding;
@@ -298,9 +304,25 @@ class FightPackRecorder:
 _active: FightPackRecorder | None = None
 
 
+def _enough_disk_for_recording() -> bool:
+    """True if the recordings drive has at least MIN_FREE_DISK_FRACTION free."""
+    path = get_recordings_dir()
+    os.makedirs(path, exist_ok=True)
+    usage = shutil.disk_usage(path)
+    return usage.free / usage.total >= MIN_FREE_DISK_FRACTION
+
+
 def start_fight_recording(emulator, fight_mode: str, version: str, logger=None, fps: float = DEFAULT_FPS) -> None:
     global _active
     finish_fight_recording(None)  # defensively close any stale recorder
+    if not _enough_disk_for_recording():
+        msg = "Recordings drive over 90% full -- skipping fight recording"
+        if logger is not None:
+            logger.log(msg)
+        else:
+            print(msg)
+        _active = None
+        return
     recorder = FightPackRecorder(logger=logger)
     try:
         recorder.start(emulator, fight_mode, version, fps=fps)

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -40,7 +40,7 @@ from pyclashbot.interface.enums import (
     has_start_ready_job,
 )
 from pyclashbot.interface.widgets import DualRingGauge
-from pyclashbot.utils.platform import is_windows
+from pyclashbot.utils.platform import clear_recordings, is_windows
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1199,6 +1199,16 @@ class PyClashBotUI(ttk.Window):
             },
         )
 
+        (self.clear_recordings_btn,) = self._compact_action_button_row(
+            data_frame,
+            {
+                "text": "Clear recordings",
+                "bootstyle": "danger",
+                "command": self._on_clear_recordings_clicked,
+                "pady": (6, 0),
+            },
+        )
+
         links_frame = self._section_labelframe(content, "Links")
         links_frame.pack(fill=X)
 
@@ -1474,6 +1484,18 @@ class PyClashBotUI(ttk.Window):
     def _on_open_recordings_clicked(self) -> None:
         if self._open_recordings_callback:
             self._open_recordings_callback()
+
+    def _on_clear_recordings_clicked(self) -> None:
+        if not messagebox.askyesno(
+            "Clear recordings",
+            "Delete ALL recorded fight packs? This cannot be undone.",
+        ):
+            return
+        removed, freed = clear_recordings()
+        messagebox.showinfo(
+            "Recordings cleared",
+            f"Deleted {removed} recording(s), freed {freed / (1024**3):.2f} GB.",
+        )
 
     def _update_advanced_settings_visibility(self, emulator_choice: str) -> None:
         show_advanced = bool(self.advanced_settings_var.get())

--- a/pyclashbot/utils/platform.py
+++ b/pyclashbot/utils/platform.py
@@ -1,6 +1,7 @@
 """Platform detection and OS-specific directory helpers."""
 
 import os
+import shutil
 import sys
 from enum import StrEnum, auto
 
@@ -45,6 +46,39 @@ def get_log_dir(app_name: str) -> str:
 def get_recordings_dir(app_name: str = "py-clash-bot") -> str:
     """Return the single source-of-truth directory for recorded fight packs."""
     return os.path.join(get_app_data_dir(app_name), "recordings")
+
+
+def _dir_size(path: str) -> int:
+    """Best-effort total size in bytes of every file under path."""
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                continue
+    return total
+
+
+def clear_recordings(app_name: str = "py-clash-bot") -> tuple[int, int]:
+    """Delete every recorded fight pack. Returns (packs_removed, bytes_freed).
+
+    Manual only: nothing in the bot calls this automatically. Wired to the
+    "Clear recordings" button in the interface.
+    """
+    rec_dir = get_recordings_dir(app_name)
+    if not os.path.isdir(rec_dir):
+        return (0, 0)
+    removed = 0
+    freed = 0
+    for name in os.listdir(rec_dir):
+        pack = os.path.join(rec_dir, name)
+        if not os.path.isdir(pack):
+            continue
+        freed += _dir_size(pack)
+        shutil.rmtree(pack, ignore_errors=True)
+        removed += 1
+    return (removed, freed)
 
 
 def is_windows() -> bool:

--- a/tests/test_fight_pack_recorder.py
+++ b/tests/test_fight_pack_recorder.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 import json
 import os
 import time
+from types import SimpleNamespace
 
 import numpy as np
 
 from pyclashbot.bot import recorder as rec
 from pyclashbot.bot.recorder import FightPackRecorder
+from pyclashbot.utils import platform as pf
 
 
 class _FakeEmu:
@@ -35,6 +37,47 @@ def _drive_one_fight(recorder: FightPackRecorder, *, fps: float = 20.0) -> str:
     slug = recorder.finish("win")
     assert slug is not None
     return os.path.join(rec.get_recordings_dir(), slug)
+
+
+def test_low_disk_space_skips_recording(tmp_path, monkeypatch):
+    """At >90% used (free < 10%), start_fight_recording records nothing."""
+    monkeypatch.setattr(rec, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+    # 95% used: 5 free of 100 total -> below the 10% floor.
+    monkeypatch.setattr(rec.shutil, "disk_usage", lambda _p: SimpleNamespace(total=100, used=95, free=5))
+
+    rec.start_fight_recording(_FakeEmu(), "1v1_classic", "vTEST", logger=None)
+
+    assert rec.is_recording() is False
+    assert not any(p.is_dir() for p in tmp_path.iterdir())
+
+
+def test_sufficient_disk_allows_recording(tmp_path, monkeypatch):
+    """With plenty of free space, recording starts normally."""
+    monkeypatch.setattr(rec, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(rec.shutil, "disk_usage", lambda _p: SimpleNamespace(total=100, used=10, free=90))
+    monkeypatch.setattr(FightPackRecorder, "_ffv1_available", lambda self: False)
+
+    rec.start_fight_recording(_FakeEmu(), "1v1_classic", "vTEST", logger=None)
+    try:
+        assert rec.is_recording() is True
+    finally:
+        rec.finish_fight_recording("win")
+    assert rec.is_recording() is False
+
+
+def test_clear_recordings_removes_all_packs(tmp_path, monkeypatch):
+    """clear_recordings() deletes every pack folder and reports freed bytes."""
+    monkeypatch.setattr(pf, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+    for slug in ("packA", "packB"):
+        frames = tmp_path / slug / "frames"
+        frames.mkdir(parents=True)
+        (frames / "0.png").write_bytes(b"x" * 1000)
+
+    removed, freed = pf.clear_recordings()
+
+    assert removed == 2
+    assert freed >= 2000
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_uuid_persisted_at_start_and_stable(tmp_path, monkeypatch):


### PR DESCRIPTION
Disk-safety hotswap for the opt-in fight recorder (shipped in v3.3.2rc1).

- Recorder skips a new pack once the recordings drive is over 90% full (free < 10%); the fight still runs, only recording is skipped. No automatic deletion.
- New `Clear recordings` button (Data settings) wipes all packs behind a confirm dialog.
- Gates the release Discord-notify job on the ANNOUNCE_DISCORD repo variable for silent re-tags.

Verified: pytest 8 passed, `ty --python-platform linux` 0 errors, ruff clean.