### PR TITLE
fix(war): handle war-boot popup and detect Training Day war page

### DIFF
--- a/pyclashbot/bot/coords.py
+++ b/pyclashbot/bot/coords.py
@@ -139,6 +139,11 @@ PLAYABLE_PLAY_REGION_LTRB = (59, 67, 355, 467)
 # Safe deadspace tap on the war page (used to dismiss the battle-confirm overlay).
 WAR_DEADSPACE_COORD = (20, 330)
 
+# War boot: the clan-war results popup ("Your Clan didn't finish!" / reward chest)
+# that can cover the main menu and intercept navigation to the war page.
+WAR_BOOT_REWARD_COORD = (221, 382)  # the reward-chest "OPEN" button
+SKIP_WAR_BOOT_BUTTON_COORDS = (208, 601)  # the bottom OK / skip button
+
 # --- Shop / daily free offer ---
 CONFIRM_COLLECT_DAILY_FREE_OFFER_BUTTON_COORDS = (210, 440)
 SHOP_PAGE_DEADSPACE_COORD = (10, 280)

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -27,6 +27,7 @@ from pyclashbot.bot.coords import (
     DECK_TABS_REGION,
     DECKS_PAGE_BUTTON_COORDS,
     OK_BUTTON_COORDS_IN_TROPHY_REWARD_PAGE,
+    WAR_BOOT_REWARD_COORD,
     WAR_EXIT_DEADSPACE_COORD,
     WAR_TAB_FROM_SOCIAL_COORD,
 )
@@ -44,6 +45,7 @@ from pyclashbot.bot.state_detect import (
     check_if_on_shop,
     check_if_on_social,
     check_if_on_war,
+    check_if_on_war_boot,
 )
 from pyclashbot.detection.image_rec import find_image
 from pyclashbot.utils.logger import Logger
@@ -484,7 +486,39 @@ def navigate_main_page(emulator, logger: Logger, start_page: str, end_page: str)
         emulator.click(x, y)
         time.sleep(2)
 
+    # The war page flashes up before the clan-war results popup ("war boot") lands
+    # on top of it, so let it settle before checking — otherwise we'd test during
+    # the flash, see the war page (popup not up yet), miss it, and get stuck behind
+    # the popup. Then click through it before the destination check.
+    if end_page == PAGE_WAR:
+        time.sleep(5)
+        if check_if_on_war_boot(emulator):
+            logger.change_status("War boot popup detected, handling it")
+            handle_war_boot(emulator, logger)
+
     return MAIN_PAGE_CHECKS[end_page](emulator)
+
+
+_WAR_BOOT_HANDLE_TIMEOUT_S = 30.0
+
+
+def handle_war_boot(emulator, logger: Logger) -> bool:
+    """Clear the clan-war results popup ("war boot") by clicking its reward until
+    the war page is reached.
+
+    Mirrors the requested "while 1: click reward; break if on war page" flow but is
+    timeout-bounded — bot/AGENTS forbids unbounded retry loops.
+    """
+    logger.change_status("Handling war boot popup...")
+    start_time = time.time()
+    while time.time() - start_time < _WAR_BOOT_HANDLE_TIMEOUT_S:
+        emulator.click(*WAR_BOOT_REWARD_COORD)
+        time.sleep(2)
+        if check_if_on_war(emulator):
+            logger.change_status("Cleared war boot popup, now on war page")
+            return True
+    logger.change_status("Timed out handling war boot popup")
+    return check_if_on_war(emulator)
 
 
 # ===== Card-page / deck-page navigation primitives ===================

--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -580,8 +580,11 @@ def check_if_on_social(emulator) -> bool:
     return True
 
 
-def check_if_on_war(emulator) -> bool:
-    iar = emulator.screenshot()
+def _matches_war_original(iar) -> bool:
+    """Original war-page fingerprint (pink river-race banner + bottom-of-page nav).
+
+    Pixels compared in raw screenshot/BGR order.
+    """
     pixels = [
         iar[18][146],
         iar[598][177],
@@ -608,6 +611,84 @@ def check_if_on_war(emulator) -> bool:
     ]
     for i, p in enumerate(pixels):
         if not pixel_is_equal(p, colors[i], tol=25):
+            return False
+    return True
+
+
+# Alternate war-page fingerprint, sampled with the click picker on the green
+# "Training Day" river-race variant that the original pink-banner palette misses.
+# (x, y, r, g, b) in RGB; each sampled pixel is flipped from BGR before comparing.
+_WAR_PAGE_ALT_PIXELS: tuple[tuple[int, int, int, int, int], ...] = (
+    (357, 53, 152, 117, 254),
+    (379, 57, 154, 119, 253),
+    (396, 41, 162, 129, 255),
+    (380, 30, 129, 161, 177),
+    (21, 606, 74, 88, 110),
+    (68, 606, 74, 88, 110),
+    (113, 608, 74, 88, 109),
+    (156, 604, 75, 89, 110),
+    (186, 604, 104, 187, 255),
+    (225, 607, 78, 175, 255),
+    (258, 608, 74, 88, 109),
+    (315, 613, 73, 87, 108),
+    (367, 612, 73, 87, 109),
+    (399, 612, 73, 87, 109),
+    (202, 604, 255, 255, 255),
+)
+
+
+def _matches_war_alt(iar) -> bool:
+    """Alternate war-page fingerprint (see _WAR_PAGE_ALT_PIXELS)."""
+    for x, y, r, g, b in _WAR_PAGE_ALT_PIXELS:
+        bgr = iar[y][x]
+        actual = [int(bgr[2]), int(bgr[1]), int(bgr[0])]
+        if not pixel_is_equal(actual, [r, g, b], tol=25):
+            return False
+    return True
+
+
+def check_if_on_war(emulator) -> bool:
+    """True when on the clan-war / river-race page.
+
+    Two independent pixel fingerprints are OR'd: either one matching confirms the
+    war page, both must fail to rule it out. The river-race banner color varies by
+    day, so add new palettes here rather than tightening existing ones.
+    """
+    iar = emulator.screenshot()
+    return _matches_war_original(iar) or _matches_war_alt(iar)
+
+
+# (x, y, r, g, b) sampled from the clan-war results popup ("war boot") — e.g. the
+# "Your Clan didn't finish!" screen with a reward chest. This modal covers the main
+# menu and intercepts navigation to the war page, so it is detected after the nav
+# clicks and then clicked through (see nav.handle_war_boot).
+_WAR_BOOT_PIXELS: tuple[tuple[int, int, int, int, int], ...] = (
+    (23, 601, 75, 89, 111),
+    (60, 599, 75, 89, 111),
+    (123, 608, 74, 88, 109),
+    (277, 608, 74, 88, 109),
+    (333, 609, 74, 88, 109),
+    (407, 613, 73, 87, 108),
+    (180, 608, 78, 175, 255),
+    (206, 606, 111, 134, 153),
+    (232, 606, 78, 175, 255),
+    (148, 390, 255, 190, 43),
+    (217, 390, 255, 190, 43),
+    (225, 371, 255, 196, 54),
+)
+
+
+def check_if_on_war_boot(emulator) -> bool:
+    """True when the clan-war results popup ("war boot") is covering the screen.
+
+    Screenshots are BGR; each sampled pixel is flipped to RGB before comparing
+    against the (x, y, r, g, b) fingerprint above.
+    """
+    iar = emulator.screenshot()
+    for x, y, r, g, b in _WAR_BOOT_PIXELS:
+        bgr = iar[y][x]
+        actual = [int(bgr[2]), int(bgr[1]), int(bgr[0])]
+        if not pixel_is_equal(actual, [r, g, b], tol=25):
             return False
     return True
 


### PR DESCRIPTION
## Summary

The war state intermittently failed at `navigate_main_page(main -> war)` with "Failed to navigate to war page," forcing an emulator restart. Two root causes:

- `check_if_on_war` only matched one river-race banner palette, so the green "Training Day" variant read as not-on-war. It now ORs a second pixel palette; either match confirms the war page.
- The clan-war results popup ("war boot") lands on top of the war page after a brief flash, intercepting navigation. `navigate_main_page` now waits for the page to settle, detects the popup via `check_if_on_war_boot`, and clears it with `handle_war_boot` before the destination check.

## Test plan

- [ ] Cycle accounts to the war page; confirm each lands on war and returns to main without a restart.
- [ ] Verify the war-boot reward popup is detected and clicked through (log shows "War boot popup detected, handling it" then "Cleared war boot popup").
- [ ] Confirm `check_if_on_war` returns True on the Training Day war page.