### PR TITLE
feat(recorder): custom recording folder with path/disk validation

### DIFF
--- a/pyclashbot/__main__.py
+++ b/pyclashbot/__main__.py
@@ -88,6 +88,9 @@ def make_job_dictionary(values: dict[str, Any]) -> dict[str, Any]:
         except (TypeError, ValueError):
             return default
 
+    def as_str(field: UIField, default: str = "") -> str:
+        return str(values.get(field.value, default) or default)
+
     job_dictionary: dict[str, Any] = {
         UIField.CARD_MASTERY_USER_TOGGLE.value: as_bool(UIField.CARD_MASTERY_USER_TOGGLE),
         UIField.SHOP_DAILY_OFFER_USER_TOGGLE.value: as_bool(UIField.SHOP_DAILY_OFFER_USER_TOGGLE),
@@ -108,6 +111,7 @@ def make_job_dictionary(values: dict[str, Any]) -> dict[str, Any]:
         UIField.RANDOM_PLAYS_USER_TOGGLE.value: as_bool(UIField.RANDOM_PLAYS_USER_TOGGLE),
         UIField.DISABLE_WIN_TRACK_TOGGLE.value: as_bool(UIField.DISABLE_WIN_TRACK_TOGGLE),
         UIField.RECORD_FIGHTS_TOGGLE.value: as_bool(UIField.RECORD_FIGHTS_TOGGLE),
+        UIField.RECORDING_FOLDER_PATH.value: as_str(UIField.RECORDING_FOLDER_PATH),
     }
 
     job_dictionary["upgrade_user_toggle"] = as_bool(UIField.CARD_UPGRADE_USER_TOGGLE)
@@ -260,7 +264,11 @@ def handle_process_finished(
 
 
 def open_recordings_folder() -> None:
-    open_folder(get_recordings_dir())
+    custom_path = None
+    if USER_SETTINGS_CACHE.exists():
+        settings = USER_SETTINGS_CACHE.load_data()
+        custom_path = settings.get(UIField.RECORDING_FOLDER_PATH.value) or None
+    open_folder(get_recordings_dir(custom_path=custom_path))
 
 
 def open_logs_folder() -> None:

--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -50,11 +50,13 @@ ELIXIR_WAIT_TIMEOUT = 40  # too high but someone got errors with that so idk
 ABILITY_TRIGGER_DELAY_S = 3
 
 
-def _maybe_start_fight_recording(emulator, logger, recording_flag: bool, fight_mode_chosen: str) -> None:
+def _maybe_start_fight_recording(
+    emulator, logger, recording_flag: bool, fight_mode_chosen: str, custom_path: str | None = None
+) -> None:
     """Begin opt-in training-data capture for 1v1-type fights only (Trophy Road / Classic 1v1, never 2v2)."""
     if recording_flag and fight_mode_chosen in ["Classic 1v1", "Trophy Road"]:
         pack_mode = "1v1_trophy" if fight_mode_chosen == "Trophy Road" else "1v1_classic"
-        start_fight_recording(emulator, pack_mode, __version__, logger=logger)
+        start_fight_recording(emulator, pack_mode, __version__, logger=logger, custom_path=custom_path)
 
 
 def do_fight_state(
@@ -64,6 +66,7 @@ def do_fight_state(
     fight_mode_chosen,
     called_from_launching=False,
     recording_flag: bool = False,
+    custom_path: str | None = None,
 ) -> bool:
     """Handle the entirety of a battle state (start fight, do fight, end fight)."""
 
@@ -80,12 +83,15 @@ def do_fight_state(
     # Recording is started/stopped inside the fight loops themselves so each pack
     # brackets exactly the in-battle play loop (no pre-battle wait or post-fight nav).
     # Run regular fight loop if random mode not toggled
-    if not random_fight_mode and _fight_loop(emulator, logger, recording_flag, fight_mode_chosen) is False:
+    if not random_fight_mode and _fight_loop(emulator, logger, recording_flag, fight_mode_chosen, custom_path) is False:
         logger.change_status("Fight loop failed")
         return False
 
     # Run random fight loop if random mode toggled
-    if random_fight_mode and _random_fight_loop(emulator, logger, recording_flag, fight_mode_chosen) is False:
+    if (
+        random_fight_mode
+        and _random_fight_loop(emulator, logger, recording_flag, fight_mode_chosen, custom_path) is False
+    ):
         logger.change_status("Fight loop failed")
         return False
 
@@ -516,10 +522,12 @@ class BattleStrategy:
         return self.phase_thresholds[phase]
 
 
-def _fight_loop(emulator, logger: Logger, recording_flag: bool, fight_mode: str = "Classic 1v1") -> bool:
+def _fight_loop(
+    emulator, logger: Logger, recording_flag: bool, fight_mode: str = "Classic 1v1", custom_path: str | None = None
+) -> bool:
     """Method for handling dynamically timed fight"""
     create_default_bridge_iar(emulator)
-    _maybe_start_fight_recording(emulator, logger, recording_flag, fight_mode)
+    _maybe_start_fight_recording(emulator, logger, recording_flag, fight_mode, custom_path)
     collections.deque(maxlen=3)
     prev_cards_played = logger.get_cards_played()
     battle_detection_lost_count = 0
@@ -599,10 +607,16 @@ def _fight_loop(emulator, logger: Logger, recording_flag: bool, fight_mode: str 
     return True
 
 
-def _random_fight_loop(emulator, logger, recording_flag: bool = False, fight_mode_chosen: str = "Trophy Road") -> bool:
+def _random_fight_loop(
+    emulator,
+    logger,
+    recording_flag: bool = False,
+    fight_mode_chosen: str = "Trophy Road",
+    custom_path: str | None = None,
+) -> bool:
     """Method for handling dynamically timed fight with random plays"""
     logger.change_status(status="Starting battle with random plays")
-    _maybe_start_fight_recording(emulator, logger, recording_flag, fight_mode_chosen)
+    _maybe_start_fight_recording(emulator, logger, recording_flag, fight_mode_chosen, custom_path)
     create_default_bridge_iar(emulator)
     fight_timeout = 5 * 60  # 5 minutes
     start_time = time.time()

--- a/pyclashbot/bot/recorder.py
+++ b/pyclashbot/bot/recorder.py
@@ -86,13 +86,15 @@ class FightPackRecorder:
 
     # ---- lifecycle ------------------------------------------------------
 
-    def start(self, emulator, fight_mode: str, version: str, fps: float = DEFAULT_FPS) -> bool:
+    def start(
+        self, emulator, fight_mode: str, version: str, fps: float = DEFAULT_FPS, custom_path: str | None = None
+    ) -> bool:
         """Begin capturing. Returns True on success (a frame thread is running)."""
         self.slug = _new_slug()
         # Stable dedup key for the importer: generated once here and persisted
         # immediately (see below), so a re-exported/re-sent pack keeps the same uuid.
         self.uuid = uuid.uuid4().hex
-        self.dir = os.path.join(get_recordings_dir(), self.slug)
+        self.dir = os.path.join(get_recordings_dir(custom_path=custom_path), self.slug)
         self.fps = fps
         self.fight_mode = fight_mode
         self.version = version
@@ -304,18 +306,27 @@ class FightPackRecorder:
 _active: FightPackRecorder | None = None
 
 
-def _enough_disk_for_recording() -> bool:
-    """True if the recordings drive has at least MIN_FREE_DISK_FRACTION free."""
-    path = get_recordings_dir()
-    os.makedirs(path, exist_ok=True)
-    usage = shutil.disk_usage(path)
+def _enough_disk_for_recording(custom_path: str | None = None) -> bool:
+    """True if the recordings drive has at least MIN_FREE_DISK_FRACTION free.
+
+    Returns False (skip recording) if the recordings folder can't be created or
+    queried -- a user-supplied custom path may be invalid or unwritable.
+    """
+    path = get_recordings_dir(custom_path=custom_path)
+    try:
+        os.makedirs(path, exist_ok=True)
+        usage = shutil.disk_usage(path)
+    except OSError:
+        return False
     return usage.free / usage.total >= MIN_FREE_DISK_FRACTION
 
 
-def start_fight_recording(emulator, fight_mode: str, version: str, logger=None, fps: float = DEFAULT_FPS) -> None:
+def start_fight_recording(
+    emulator, fight_mode: str, version: str, logger=None, fps: float = DEFAULT_FPS, custom_path: str | None = None
+) -> None:
     global _active
     finish_fight_recording(None)  # defensively close any stale recorder
-    if not _enough_disk_for_recording():
+    if not _enough_disk_for_recording(custom_path):
         msg = "Recordings drive over 90% full -- skipping fight recording"
         if logger is not None:
             logger.log(msg)
@@ -325,7 +336,7 @@ def start_fight_recording(emulator, fight_mode: str, version: str, logger=None, 
         return
     recorder = FightPackRecorder(logger=logger)
     try:
-        recorder.start(emulator, fight_mode, version, fps=fps)
+        recorder.start(emulator, fight_mode, version, fps=fps, custom_path=custom_path)
         _active = recorder
     except Exception as e:
         if logger is not None:

--- a/pyclashbot/bot/recording_archiver.py
+++ b/pyclashbot/bot/recording_archiver.py
@@ -1,0 +1,255 @@
+"""Periodic, crash-safe archiving of recorded fight packs into ~5 GB zip bundles.
+
+The recorder writes one folder per fight into the recordings directory (see
+``recorder.py``). Those packs accumulate quickly. ``maybe_archive_recordings``
+is called after each finished fight: when the loose packs in the recordings
+folder exceed :data:`ARCHIVE_THRESHOLD_BYTES`, it peels the *oldest* whole packs
+off (never splitting a pack) until it has gathered about :data:`TARGET_ARCHIVE_BYTES`,
+bundles them into a single ``.zip`` in the sibling ``recording-zips`` folder, and
+deletes the source packs.
+
+Idempotency / crash-safety
+--------------------------
+The worker is stopped by an OS-level ``terminate()`` (see the root AGENTS.md), so
+this routine can die at any instruction. Two failure modes matter, both about
+disk, not data: losing the odd fight is fine, but **duplicated packs** and
+**unbounded disk growth** are not. The protocol below is self-healing against an
+abort at any point, because it makes the rename the single commit point and then
+*reconciles* on the next run rather than trusting the previous one finished:
+
+1. **Sweep orphan ``*.zip.tmp``** every call (a zip whose write was interrupted
+   before the atomic rename). These are never read; deleting them caps disk
+   growth, and the sweep is a single directory scan with no archive reads.
+2. **Reconcile** committed archives, but only once loose packs cross the threshold
+   and we are about to archive. Every finalized ``.zip`` lists its member slugs in
+   its central directory; for each, delete any source pack still on disk. This
+   finishes a delete a crash interrupted and, crucially, runs *before* a new batch
+   is selected, so a pack already inside a committed archive can never be
+   re-selected and re-zipped -> no duplicates. Reading every archive's directory
+   on every fight would be wasted I/O that grows with the (unbounded) archive
+   count, so it is deferred to the archive path; a leftover straggler simply waits
+   to be reclaimed until the next run that archives.
+3. **Archive**: write to ``<name>.zip.tmp``, then ``os.replace`` to the final
+   name (atomic = the commit point), then delete the sources. A crash before
+   the rename leaves only an orphan tmp (swept next run, sources intact); a crash
+   after the rename leaves a valid archive whose stragglers reconcile finishes.
+
+Why zip and not tar
+-------------------
+Tarballs do not help here: idempotency comes from the commit-then-reconcile
+protocol, not the container. Worse, reconcile needs to list an archive's member
+slugs cheaply, and zip's central directory makes that O(1) without reading the
+payload, whereas a tar must be scanned sequentially (or carry a sidecar index).
+And because we only ever read archives we committed via ``os.replace``, a zip's
+"central directory required to read" property is always satisfied.
+
+Packs are zipped with ``ZIP_STORED`` (no compression): the captured media (FFV1
+``.mkv`` / PNG frames) is already compressed, so deflating it wastes CPU for no
+size gain -- the goal here is *bundling* loose 5 GB chunks, not shrinking them.
+
+Slugs sort lexically in chronological order (``%Y%m%d-%H%M%S-<hex>``), so the
+oldest packs are simply the first ones after a plain sort.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import zipfile
+
+from pyclashbot.utils.platform import (
+    _PACK_SLUG_RE,
+    _dir_size,
+    get_recording_zips_dir,
+    get_recordings_dir,
+)
+
+# Start archiving once loose packs exceed this; gather about this much per run.
+ARCHIVE_THRESHOLD_BYTES = 5 * 1024**3  # 5 GB
+TARGET_ARCHIVE_BYTES = 5 * 1024**3  # 5 GB
+
+
+def _log(logger, message: str) -> None:
+    if logger is not None:
+        logger.log(message)
+    else:
+        print(message)
+
+
+def _pack_dirs_oldest_first(rec_dir: str) -> list[str]:
+    """Slug-named pack directory names in chronological (oldest-first) order."""
+    if not os.path.isdir(rec_dir):
+        return []
+    names = [
+        name for name in os.listdir(rec_dir) if _PACK_SLUG_RE.match(name) and os.path.isdir(os.path.join(rec_dir, name))
+    ]
+    return sorted(names)
+
+
+def _archived_slugs(zip_path: str) -> set[str]:
+    """Top-level slug folders recorded inside a committed archive.
+
+    Members are stored as ``<slug>/...``; the first path component is the slug.
+    Returns an empty set if the archive can't be read.
+    """
+    slugs: set[str] = set()
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            for member in zf.namelist():
+                head = member.replace("\\", "/").split("/", 1)[0]
+                if _PACK_SLUG_RE.match(head):
+                    slugs.add(head)
+    except (OSError, zipfile.BadZipFile):
+        return set()
+    return slugs
+
+
+def _sweep_orphan_tmps(zips_dir: str, logger) -> None:
+    """Delete orphan ``*.zip.tmp`` files (a write interrupted before the atomic
+    rename). Cheap -- a single directory scan, no archive reads -- so it is safe
+    to run on every call to cap disk growth from abandoned temp archives.
+    """
+    if not os.path.isdir(zips_dir):
+        return
+    for name in os.listdir(zips_dir):
+        if name.lower().endswith(".zip.tmp"):
+            try:
+                os.remove(os.path.join(zips_dir, name))
+            except OSError:
+                pass
+
+
+def _reconcile(rec_dir: str, zips_dir: str, logger) -> set[str]:
+    """Finish interrupted deletes from committed archives.
+
+    Reads each committed ``.zip``'s central directory, so this runs only on the
+    archive path (not every fight). Returns the set of slugs now (or already)
+    safely inside a committed archive, so the caller can exclude them from a new
+    batch even if rmtree below fails to remove every straggler.
+    """
+    archived: set[str] = set()
+    if not os.path.isdir(zips_dir):
+        return archived
+    for name in os.listdir(zips_dir):
+        path = os.path.join(zips_dir, name)
+        if not os.path.isfile(path) or not name.lower().endswith(".zip"):
+            continue
+        for slug in _archived_slugs(path):
+            archived.add(slug)
+            stale = os.path.join(rec_dir, slug)
+            if os.path.isdir(stale):
+                # Pack is already committed to this archive but its source
+                # survived a crash mid-delete; remove it now (idempotent).
+                shutil.rmtree(stale, ignore_errors=True)
+                _log(logger, f"Recording archiver: reclaimed already-archived pack {slug}")
+    return archived
+
+
+def _select_batch(rec_dir: str, packs: list[str]) -> tuple[list[str], int]:
+    """Pick oldest whole packs until the cumulative size reaches the target.
+
+    Returns (selected_slugs, total_loose_bytes). Whole packs only -- a pack is
+    never split across archives.
+    """
+    selected: list[str] = []
+    selected_bytes = 0
+    total_bytes = 0
+    for name in packs:
+        size = _dir_size(os.path.join(rec_dir, name))
+        total_bytes += size
+        if selected_bytes < TARGET_ARCHIVE_BYTES:
+            selected.append(name)
+            selected_bytes += size
+    return selected, total_bytes
+
+
+def _zip_path(zips_dir: str, slugs: list[str]) -> str:
+    """A unique ``.zip`` path named for the first..last slug in the batch."""
+    base = f"packs-{slugs[0]}__{slugs[-1]}"
+    candidate = os.path.join(zips_dir, base + ".zip")
+    suffix = 1
+    while os.path.exists(candidate):
+        candidate = os.path.join(zips_dir, f"{base}-{suffix}.zip")
+        suffix += 1
+    return candidate
+
+
+def maybe_archive_recordings(logger=None, custom_path: str | None = None) -> str | None:
+    """Bundle ~5 GB of the oldest recording packs into a zip when the loose
+    recordings exceed the threshold. Returns the zip path written, else None.
+
+    Safe to call after every fight and crash-safe at any point (see module
+    docstring): it sweeps abandoned temp archives, then does nothing (a cheap
+    pack scan) until loose packs cross :data:`ARCHIVE_THRESHOLD_BYTES`, at which
+    point it reconciles prior interrupted runs before selecting a batch. It only
+    ever archives one ~5 GB batch per call so the worker pause stays bounded. Any
+    failure is logged and swallowed -- archiving must never break the bot loop,
+    and source packs are only deleted after the archive is fully written and
+    atomically renamed.
+    """
+    rec_dir = get_recordings_dir(custom_path=custom_path)
+    zips_dir = get_recording_zips_dir(custom_path=custom_path)
+
+    # Cheap every-fight work: sweep abandoned temp archives, then bail unless the
+    # loose packs have crossed the threshold. The per-archive reconcile (which
+    # opens every committed zip) is deferred to the archive path below.
+    _sweep_orphan_tmps(zips_dir, logger)
+
+    packs = _pack_dirs_oldest_first(rec_dir)
+    selected, total_bytes = _select_batch(rec_dir, packs)
+    if total_bytes < ARCHIVE_THRESHOLD_BYTES or not selected:
+        return None
+
+    # About to archive: reconcile committed archives so a pack a prior crashed run
+    # already committed is healed and excluded here, never re-selected -> no dupes.
+    already_archived = _reconcile(rec_dir, zips_dir, logger)
+    if already_archived:
+        packs = [p for p in packs if p not in already_archived]
+        selected, total_bytes = _select_batch(rec_dir, packs)
+        if total_bytes < ARCHIVE_THRESHOLD_BYTES or not selected:
+            return None
+
+    try:
+        os.makedirs(zips_dir, exist_ok=True)
+    except OSError as e:
+        _log(logger, f"Recording archiver: cannot create zips folder {zips_dir}: {e}")
+        return None
+
+    final_path = _zip_path(zips_dir, selected)
+    tmp_path = final_path + ".tmp"
+    selected_bytes = 0
+    try:
+        with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
+            for slug in selected:
+                pack_dir = os.path.join(rec_dir, slug)
+                for root, _dirs, files in os.walk(pack_dir):
+                    for fname in files:
+                        abs_path = os.path.join(root, fname)
+                        # arcname keeps the "<slug>/..." layout inside the zip
+                        # (reconcile reads the slug back from this first component).
+                        arcname = os.path.relpath(abs_path, rec_dir)
+                        zf.write(abs_path, arcname)
+            selected_bytes = sum(zinfo.file_size for zinfo in zf.infolist())
+        os.replace(tmp_path, final_path)  # atomic commit point
+    except (OSError, zipfile.BadZipFile) as e:
+        _log(logger, f"Recording archiver: failed to write {final_path}: {e}")
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+        return None
+
+    # Archive is committed; delete the sources. A crash here is harmless: the
+    # next run's reconcile finishes the deletion from the committed archive.
+    removed = 0
+    for slug in selected:
+        shutil.rmtree(os.path.join(rec_dir, slug), ignore_errors=True)
+        removed += 1
+
+    _log(
+        logger,
+        f"Recording archiver: bundled {removed} pack(s) "
+        f"(~{selected_bytes / 1024**3:.2f} GB) into {os.path.basename(final_path)}",
+    )
+    return final_path

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -13,6 +13,7 @@ from pyclashbot.bot.fight import (
     start_fight,
 )
 from pyclashbot.bot.nav import select_mode
+from pyclashbot.bot.recording_archiver import maybe_archive_recordings
 from pyclashbot.bot.shop_daily_state import shop_daily_state
 from pyclashbot.bot.state_detect import check_if_battle_mode_is_selected
 from pyclashbot.bot.upgrade_state import upgrade_cards_state
@@ -552,6 +553,12 @@ def state_tree(
             is False
         ):
             return handle_state_failure(logger, "end_fight", "end_fight_state", "Failed to end fight properly")
+
+        # When recording, periodically bundle ~5 GB of the oldest packs into a zip
+        # so the loose recordings folder doesn't grow without bound.
+        if recording_flag:
+            custom_path = job_list.get(UIField.RECORDING_FOLDER_PATH, None)
+            maybe_archive_recordings(logger=logger, custom_path=custom_path)
 
         return state_order.next_state(state)
 

--- a/pyclashbot/bot/states.py
+++ b/pyclashbot/bot/states.py
@@ -491,6 +491,7 @@ def state_tree(
         random_plays_flag = job_list.get(UIField.RANDOM_PLAYS_USER_TOGGLE, False)
 
         recording_flag = job_list.get(UIField.RECORD_FIGHTS_TOGGLE, False)
+        custom_path = job_list.get(UIField.RECORDING_FOLDER_PATH, None)
         if (
             do_fight_state(
                 emulator,
@@ -498,7 +499,8 @@ def state_tree(
                 random_plays_flag,
                 mode_used_in_1v1,
                 False,
-                recording_flag,
+                recording_flag=recording_flag,
+                custom_path=custom_path,
             )
             is False
         ):
@@ -516,6 +518,7 @@ def state_tree(
 
         random_plays_flag = job_list.get(UIField.RANDOM_PLAYS_USER_TOGGLE, False)
 
+        custom_path = job_list.get(UIField.RECORDING_FOLDER_PATH, None)
         # 2v2 fights are never recorded (training data is 1v1-only: Trophy Road + Classic 1v1).
         if (
             do_fight_state(
@@ -525,6 +528,7 @@ def state_tree(
                 "Classic 2v2",
                 called_from_launching=False,
                 recording_flag=False,
+                custom_path=custom_path,
             )
             is False
         ):

--- a/pyclashbot/interface/config.py
+++ b/pyclashbot/interface/config.py
@@ -259,7 +259,11 @@ USER_CONFIG_KEYS = (
     _job_setting_keys()
     + [radio.key.value for radio in MEMU_SETTINGS + BLUESTACKS_SETTINGS + EMULATOR_CHOICE]
     + [combo.key.value for combo in GOOGLE_PLAY_SETTINGS]
-    + [UIField.THEME_NAME.value, UIField.RECORD_FIGHTS_TOGGLE.value]  # Data settings
+    + [
+        UIField.THEME_NAME.value,
+        UIField.RECORD_FIGHTS_TOGGLE.value,
+        UIField.RECORDING_FOLDER_PATH.value,
+    ]  # Data settings
     + [UIField.GP_DEVICE_SERIAL.value, UIField.BS_DEVICE_SERIAL.value]  # Device serial settings
 )
 

--- a/pyclashbot/interface/enums.py
+++ b/pyclashbot/interface/enums.py
@@ -53,6 +53,7 @@ class UIField(StrEnum):
     RANDOM_PLAYS_USER_TOGGLE = "random_plays_user_toggle"
     DISABLE_WIN_TRACK_TOGGLE = "disable_win_track_toggle"
     RECORD_FIGHTS_TOGGLE = "record_fights_toggle"
+    RECORDING_FOLDER_PATH = "recording_folder_path"
     OPENGL_TOGGLE = "opengl_toggle"
     DIRECTX_TOGGLE = "directx_toggle"
     BS_RENDERER_GL = "bs_renderer_gl"

--- a/pyclashbot/interface/ui.py
+++ b/pyclashbot/interface/ui.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import sys
+import threading
 import tkinter as tk
+import tkinter.filedialog
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
@@ -40,7 +42,15 @@ from pyclashbot.interface.enums import (
     has_start_ready_job,
 )
 from pyclashbot.interface.widgets import DualRingGauge
-from pyclashbot.utils.platform import clear_recordings, is_windows
+from pyclashbot.utils.platform import (
+    LOW_DISK_SPACE_BYTES,
+    clear_recordings,
+    get_recordings_dir,
+    is_windows,
+    recordings_drive_free_bytes,
+    recordings_total_bytes_all_locations,
+    validate_recordings_path,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -113,6 +123,9 @@ _WIN_GAUGE_THICKNESS = 8
 _APP_ICON_NAME = "pixel-pycb.ico"
 _DISCORD_INVITE_URL = "https://pyclashbot.app/discord/invite"
 _GITHUB_PROJECT_URL = "https://github.com/pyclashbot/py-clash-bot"
+_UPLOAD_RECORDINGS_URL = "https://www.royaletrainer.com/upload"
+# How often the "recordings using N GB" note recomputes folder size (ms).
+_RECORDINGS_SIZE_REFRESH_MS = 3 * 60 * 1000  # 3 minutes
 _DISCORD_BRAND = "#5865F2"
 _GITHUB_BRAND = "#238636"
 _DISCORD_BUTTON_STYLE = "App.Discord.TButton"
@@ -145,6 +158,8 @@ class PyClashBotUI(ttk.Window):
         self.theme_var = ttk.StringVar(value=current_theme)
         self.discord_rpc_var = ttk.BooleanVar(value=False)
         self.record_fights_var = ttk.BooleanVar(value=False)
+        # Show the resolved default location in the box until the user picks a custom one.
+        self.recording_folder_path_var = ttk.StringVar(value=get_recordings_dir())
         self.advanced_settings_var = ttk.BooleanVar(value=False)
         self._config_callback: Callable[[dict[str, object]], None] | None = None
         self._open_logs_callback: Callable[[], None] | None = None
@@ -227,6 +242,7 @@ class PyClashBotUI(ttk.Window):
         values[UIField.THEME_NAME.value] = self.theme_var.get() or self.DEFAULT_THEME
         values[UIField.DISCORD_RPC_TOGGLE.value] = bool(self.discord_rpc_var.get())
         values[UIField.RECORD_FIGHTS_TOGGLE.value] = bool(self.record_fights_var.get())
+        values[UIField.RECORDING_FOLDER_PATH.value] = self.recording_folder_path_var.get() or ""
         return values
 
     def set_all_values(self, values: dict[str, object]) -> None:
@@ -320,6 +336,11 @@ class PyClashBotUI(ttk.Window):
 
         if UIField.RECORD_FIGHTS_TOGGLE.value in values:
             self.record_fights_var.set(bool(values[UIField.RECORD_FIGHTS_TOGGLE.value]))
+
+        if UIField.RECORDING_FOLDER_PATH.value in values:
+            saved_path = str(values[UIField.RECORDING_FOLDER_PATH.value])
+            # An empty saved value means "default" -- show the resolved default path.
+            self.recording_folder_path_var.set(saved_path or get_recordings_dir())
 
         self._show_current_emulator_settings()
 
@@ -1185,21 +1206,60 @@ class PyClashBotUI(ttk.Window):
         self._trace_variable(self.record_fights_var)
         self._register_config_widget(UIField.RECORD_FIGHTS_TOGGLE.value, record_fights_checkbox)
 
+        # Recording folder path picker
+        recording_folder_frame = ttk.Frame(data_frame)
+        recording_folder_frame.pack(fill=X, pady=(0, 2))
+
+        ttk.Label(
+            recording_folder_frame,
+            text="Recording folder:",
+            font=("TkDefaultFont", 9),
+        ).pack(side=LEFT, padx=(0, 5))
+
+        recording_folder_entry = ttk.Entry(
+            recording_folder_frame,
+            textvariable=self.recording_folder_path_var,
+            width=40,
+        )
+        recording_folder_entry.pack(side=LEFT, fill=X, expand=True, padx=(0, 5))
+
+        browse_folder_btn = ttk.Button(
+            recording_folder_frame,
+            text="Browse...",
+            width=10,
+            command=self._on_browse_recording_folder,
+        )
+        browse_folder_btn.pack(side=LEFT)
+        self._trace_variable(self.recording_folder_path_var)
+        self._register_config_widget(UIField.RECORDING_FOLDER_PATH.value, recording_folder_entry)
+
+        # Live validation feedback for the recording folder path.
+        self.recording_folder_feedback = ttk.Label(
+            data_frame,
+            text="",
+            font=("TkDefaultFont", 8),
+            bootstyle="secondary",
+        )
+        self.recording_folder_feedback.pack(anchor="w", pady=(0, 0))
+        feedback_trace = self.recording_folder_path_var.trace_add("write", self._update_recording_folder_feedback)
+        self._traces.append((self.recording_folder_path_var, feedback_trace))
+        self._update_recording_folder_feedback()
+
         self.open_logs_btn, self.open_recordings_btn = self._compact_action_button_row(
             data_frame,
             {
-                "text": "Open logs folder",
+                "text": "View Logs",
                 "bootstyle": "secondary",
                 "command": self._on_open_logs_clicked,
             },
             {
-                "text": "Browse recorded games",
+                "text": "View Recordings",
                 "bootstyle": "secondary",
                 "command": self._on_open_recordings_clicked,
             },
         )
 
-        (self.clear_recordings_btn,) = self._compact_action_button_row(
+        self.clear_recordings_btn, self.upload_recordings_btn = self._compact_action_button_row(
             data_frame,
             {
                 "text": "Clear recordings",
@@ -1207,7 +1267,23 @@ class PyClashBotUI(ttk.Window):
                 "command": self._on_clear_recordings_clicked,
                 "pady": (6, 0),
             },
+            {
+                "text": "Upload Recordings",
+                "bootstyle": "info",
+                "command": lambda: webbrowser.open(_UPLOAD_RECORDINGS_URL),
+                "pady": (6, 0),
+            },
         )
+
+        # Small auto-updating note showing total disk used by recordings.
+        self.recordings_size_label = ttk.Label(
+            data_frame,
+            text="Recordings: calculating...",
+            font=("TkDefaultFont", 8),
+            bootstyle="secondary",
+        )
+        self.recordings_size_label.pack(anchor="center", pady=(6, 0))
+        self._schedule_recordings_size_refresh()
 
         links_frame = self._section_labelframe(content, "Links")
         links_frame.pack(fill=X)
@@ -1485,13 +1561,73 @@ class PyClashBotUI(ttk.Window):
         if self._open_recordings_callback:
             self._open_recordings_callback()
 
+    def _on_browse_recording_folder(self) -> None:
+        folder = tkinter.filedialog.askdirectory(
+            title="Select Recording Folder",
+            initialdir=self.recording_folder_path_var.get() or None,
+        )
+        if folder:
+            self.recording_folder_path_var.set(folder)
+
+    def _schedule_recordings_size_refresh(self) -> None:
+        """Refresh the recordings-size note now and re-arm the next refresh."""
+        self._refresh_recordings_size()
+        self.after(_RECORDINGS_SIZE_REFRESH_MS, self._schedule_recordings_size_refresh)
+
+    def _refresh_recordings_size(self) -> None:
+        """Compute total recordings size off the UI thread, then update the note."""
+        # Read the tk variable on the main thread; it isn't thread-safe.
+        custom_path = self.recording_folder_path_var.get() or None
+
+        def worker() -> None:
+            try:
+                total = recordings_total_bytes_all_locations(custom_path=custom_path)
+            except OSError:
+                return
+            gb = total / (1024**3)
+            self.after(0, lambda: self._set_recordings_size_text(gb))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _set_recordings_size_text(self, gb: float) -> None:
+        label = getattr(self, "recordings_size_label", None)
+        if label is None:
+            return
+        try:
+            label.configure(text=f"Recordings using {gb:.2f} GB")
+        except tk.TclError:
+            pass  # window was closed before this callback ran
+
+    def _update_recording_folder_feedback(self, *_: object) -> None:
+        """Show path-validity and low-disk-space feedback under the folder field."""
+        label = getattr(self, "recording_folder_feedback", None)
+        if label is None:
+            return
+        custom_path = self.recording_folder_path_var.get() or None
+
+        ok, message = validate_recordings_path(custom_path)
+        if not ok:
+            label.configure(text=message, bootstyle="danger")
+            return
+
+        free = recordings_drive_free_bytes(custom_path)
+        if free is not None and free <= LOW_DISK_SPACE_BYTES:
+            label.configure(
+                text="Warning: low drive space. Clean up or export some recordings.",
+                bootstyle="danger",
+            )
+            return
+
+        # No note when the path is valid -- only surface problems.
+        label.configure(text="")
+
     def _on_clear_recordings_clicked(self) -> None:
         if not messagebox.askyesno(
             "Clear recordings",
             "Delete ALL recorded fight packs? This cannot be undone.",
         ):
             return
-        removed, freed = clear_recordings()
+        removed, freed = clear_recordings(custom_path=self.recording_folder_path_var.get() or None)
         messagebox.showinfo(
             "Recordings cleared",
             f"Deleted {removed} recording(s), freed {freed / (1024**3):.2f} GB.",

--- a/pyclashbot/utils/platform.py
+++ b/pyclashbot/utils/platform.py
@@ -1,9 +1,15 @@
 """Platform detection and OS-specific directory helpers."""
 
 import os
+import re
 import shutil
 import sys
 from enum import StrEnum, auto
+
+# A recorded fight pack is a directory named "%Y%m%d-%H%M%S-<6 hex>" (see
+# recorder._new_slug). Clearing only matches this pattern so that pointing the
+# recordings folder at a user-chosen directory never deletes unrelated content.
+_PACK_SLUG_RE = re.compile(r"^\d{8}-\d{6}-[0-9a-f]{6}$")
 
 
 class Platform(StrEnum):
@@ -43,9 +49,78 @@ def get_log_dir(app_name: str) -> str:
     return os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), app_name, "logs")
 
 
-def get_recordings_dir(app_name: str = "py-clash-bot") -> str:
-    """Return the single source-of-truth directory for recorded fight packs."""
+def get_recordings_dir(app_name: str = "py-clash-bot", custom_path: str | None = None) -> str:
+    """Return the single source-of-truth directory for recorded fight packs.
+
+    Args:
+        app_name: Application name for default path construction.
+        custom_path: Optional user-specified recording folder path.
+
+    Returns:
+        The custom path if provided and non-empty, otherwise the default
+        OS-appropriate recordings directory.
+    """
+    if custom_path and custom_path.strip():
+        return custom_path.strip()
     return os.path.join(get_app_data_dir(app_name), "recordings")
+
+
+def validate_recordings_path(custom_path: str | None) -> tuple[bool, str]:
+    """Validate a user-supplied recordings folder. Returns (is_ok, message).
+
+    Empty/whitespace is valid -- it falls back to the default app-data location.
+    A non-empty path is valid when recordings can be written there: either it is
+    an existing writable directory, or it does not exist yet but its nearest
+    existing ancestor is a writable directory (so it can be created on demand).
+    The message is suitable for display next to the folder field.
+    """
+    if not custom_path or not custom_path.strip():
+        return (True, "Using default recordings folder.")
+
+    path = custom_path.strip()
+    if os.path.exists(path):
+        if not os.path.isdir(path):
+            return (False, "Path is a file, not a folder.")
+        if not os.access(path, os.W_OK):
+            return (False, "Folder exists but is not writable.")
+        return (True, "Folder is valid and writable.")
+
+    # Path does not exist yet: walk up to the nearest existing ancestor and
+    # check whether we could create the folder there.
+    ancestor = os.path.dirname(os.path.abspath(path))
+    while ancestor and not os.path.exists(ancestor):
+        parent = os.path.dirname(ancestor)
+        if parent == ancestor:  # reached a filesystem root that doesn't exist
+            break
+        ancestor = parent
+    if not ancestor or not os.path.isdir(ancestor) or not os.access(ancestor, os.W_OK):
+        return (False, "Folder does not exist and cannot be created here.")
+    return (True, "Folder will be created when recording starts.")
+
+
+# Absolute free-space floor (in bytes) below which the UI warns the user that the
+# recordings drive is running low. Distinct from recorder.MIN_FREE_DISK_FRACTION,
+# which is a percentage gate that stops new recordings.
+LOW_DISK_SPACE_BYTES = 10 * 1024**3  # 10 GB
+
+
+def recordings_drive_free_bytes(custom_path: str | None = None) -> int | None:
+    """Free bytes on the drive that holds the recordings folder.
+
+    Resolves the recordings directory (default or custom) and walks up to the
+    nearest existing ancestor to query the drive. Returns None if the drive
+    can't be determined (e.g. an invalid path on a missing root).
+    """
+    path = get_recordings_dir(custom_path=custom_path)
+    while path and not os.path.exists(path):
+        parent = os.path.dirname(path)
+        if parent == path:
+            return None
+        path = parent
+    try:
+        return shutil.disk_usage(path).free
+    except OSError:
+        return None
 
 
 def _dir_size(path: str) -> int:
@@ -60,13 +135,52 @@ def _dir_size(path: str) -> int:
     return total
 
 
-def clear_recordings(app_name: str = "py-clash-bot") -> tuple[int, int]:
+def recordings_total_bytes(app_name: str = "py-clash-bot", custom_path: str | None = None) -> int:
+    """Total bytes used by recorded fight packs in the recordings folder.
+
+    Counts only slug-named pack directories (the same set "Clear recordings"
+    would remove), so unrelated content in a custom folder is ignored. Returns
+    0 if the folder doesn't exist yet.
+    """
+    rec_dir = get_recordings_dir(app_name, custom_path)
+    if not os.path.isdir(rec_dir):
+        return 0
+    total = 0
+    for name in os.listdir(rec_dir):
+        pack = os.path.join(rec_dir, name)
+        if os.path.isdir(pack) and _PACK_SLUG_RE.match(name):
+            total += _dir_size(pack)
+    return total
+
+
+def recordings_total_bytes_all_locations(app_name: str = "py-clash-bot", custom_path: str | None = None) -> int:
+    """Total recording bytes across the default folder and the custom one.
+
+    Always counts the default app-data recordings folder; when a custom folder
+    is set and resolves to a different directory, its packs are added too. The
+    two are de-duplicated by normalized path so a custom path equal to the
+    default isn't counted twice.
+    """
+    default_dir = os.path.normcase(os.path.abspath(get_recordings_dir(app_name)))
+    total = recordings_total_bytes(app_name)
+    if custom_path and custom_path.strip():
+        custom_dir = os.path.normcase(os.path.abspath(get_recordings_dir(app_name, custom_path)))
+        if custom_dir != default_dir:
+            total += recordings_total_bytes(app_name, custom_path)
+    return total
+
+
+def clear_recordings(app_name: str = "py-clash-bot", custom_path: str | None = None) -> tuple[int, int]:
     """Delete every recorded fight pack. Returns (packs_removed, bytes_freed).
 
     Manual only: nothing in the bot calls this automatically. Wired to the
     "Clear recordings" button in the interface.
+
+    Args:
+        app_name: Application name for default path construction.
+        custom_path: Optional user-specified recording folder path.
     """
-    rec_dir = get_recordings_dir(app_name)
+    rec_dir = get_recordings_dir(app_name, custom_path)
     if not os.path.isdir(rec_dir):
         return (0, 0)
     removed = 0
@@ -74,6 +188,10 @@ def clear_recordings(app_name: str = "py-clash-bot") -> tuple[int, int]:
     for name in os.listdir(rec_dir):
         pack = os.path.join(rec_dir, name)
         if not os.path.isdir(pack):
+            continue
+        # Only delete directories that match the recording-pack slug pattern.
+        # A custom recordings folder may hold unrelated user content.
+        if not _PACK_SLUG_RE.match(name):
             continue
         freed += _dir_size(pack)
         shutil.rmtree(pack, ignore_errors=True)

--- a/pyclashbot/utils/platform.py
+++ b/pyclashbot/utils/platform.py
@@ -65,6 +65,18 @@ def get_recordings_dir(app_name: str = "py-clash-bot", custom_path: str | None =
     return os.path.join(get_app_data_dir(app_name), "recordings")
 
 
+def get_recording_zips_dir(app_name: str = "py-clash-bot", custom_path: str | None = None) -> str:
+    """Return the directory that holds archived (zipped) recording packs.
+
+    A ``zips`` subfolder *inside* the recordings folder, so archives stay under
+    the same (already-validated, user-chosen or default) directory as the loose
+    packs -- the default layout is ``<app-data>/recordings/zips``. The ``zips``
+    name never matches the pack slug pattern, so pack scans and the "Clear
+    recordings" pack loop ignore it.
+    """
+    return os.path.join(get_recordings_dir(app_name, custom_path), "zips")
+
+
 def validate_recordings_path(custom_path: str | None) -> tuple[bool, str]:
     """Validate a user-supplied recordings folder. Returns (is_ok, message).
 
@@ -153,20 +165,40 @@ def recordings_total_bytes(app_name: str = "py-clash-bot", custom_path: str | No
     return total
 
 
-def recordings_total_bytes_all_locations(app_name: str = "py-clash-bot", custom_path: str | None = None) -> int:
-    """Total recording bytes across the default folder and the custom one.
+def recording_zips_total_bytes(app_name: str = "py-clash-bot", custom_path: str | None = None) -> int:
+    """Total bytes used by archived (``.zip``) recording packs in the zips folder.
 
-    Always counts the default app-data recordings folder; when a custom folder
-    is set and resolves to a different directory, its packs are added too. The
-    two are de-duplicated by normalized path so a custom path equal to the
-    default isn't counted twice.
+    Counts only ``.zip`` files (the archives produced by recording_archiver), so
+    unrelated content in the folder is ignored. Returns 0 if it doesn't exist yet.
+    """
+    zips_dir = get_recording_zips_dir(app_name, custom_path)
+    if not os.path.isdir(zips_dir):
+        return 0
+    total = 0
+    for name in os.listdir(zips_dir):
+        path = os.path.join(zips_dir, name)
+        if os.path.isfile(path) and name.lower().endswith(".zip"):
+            try:
+                total += os.path.getsize(path)
+            except OSError:
+                continue
+    return total
+
+
+def recordings_total_bytes_all_locations(app_name: str = "py-clash-bot", custom_path: str | None = None) -> int:
+    """Total recording bytes (loose packs + zip archives) across all locations.
+
+    Always counts the default app-data recordings folder and its zips folder;
+    when a custom folder is set and resolves to a different directory, its packs
+    and zips are added too. Locations are de-duplicated by normalized path so a
+    custom path equal to the default isn't counted twice.
     """
     default_dir = os.path.normcase(os.path.abspath(get_recordings_dir(app_name)))
-    total = recordings_total_bytes(app_name)
+    total = recordings_total_bytes(app_name) + recording_zips_total_bytes(app_name)
     if custom_path and custom_path.strip():
         custom_dir = os.path.normcase(os.path.abspath(get_recordings_dir(app_name, custom_path)))
         if custom_dir != default_dir:
-            total += recordings_total_bytes(app_name, custom_path)
+            total += recordings_total_bytes(app_name, custom_path) + recording_zips_total_bytes(app_name, custom_path)
     return total
 
 
@@ -196,6 +228,13 @@ def clear_recordings(app_name: str = "py-clash-bot", custom_path: str | None = N
         freed += _dir_size(pack)
         shutil.rmtree(pack, ignore_errors=True)
         removed += 1
+    # Also drop archived zip bundles (recording_archiver output) so the button
+    # reclaims all recording space, not just loose packs. Their bytes count toward
+    # bytes_freed; packs_removed stays a count of loose pack folders.
+    zips_dir = get_recording_zips_dir(app_name, custom_path)
+    if os.path.isdir(zips_dir):
+        freed += _dir_size(zips_dir)
+        shutil.rmtree(zips_dir, ignore_errors=True)
     return (removed, freed)
 
 

--- a/tests/test_fight_pack_recorder.py
+++ b/tests/test_fight_pack_recorder.py
@@ -68,7 +68,7 @@ def test_sufficient_disk_allows_recording(tmp_path, monkeypatch):
 def test_clear_recordings_removes_all_packs(tmp_path, monkeypatch):
     """clear_recordings() deletes every pack folder and reports freed bytes."""
     monkeypatch.setattr(pf, "get_recordings_dir", lambda *a, **k: str(tmp_path))
-    for slug in ("packA", "packB"):
+    for slug in ("20240101-120000-abc123", "20240102-130000-def456"):
         frames = tmp_path / slug / "frames"
         frames.mkdir(parents=True)
         (frames / "0.png").write_bytes(b"x" * 1000)
@@ -78,6 +78,29 @@ def test_clear_recordings_removes_all_packs(tmp_path, monkeypatch):
     assert removed == 2
     assert freed >= 2000
     assert list(tmp_path.iterdir()) == []
+
+
+def test_clear_recordings_preserves_unrelated_dirs(tmp_path, monkeypatch):
+    """A custom recordings folder may hold unrelated content -- only slug-named
+    pack folders are deleted, everything else is left untouched."""
+    monkeypatch.setattr(pf, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+
+    pack = tmp_path / "20240101-120000-abc123" / "frames"
+    pack.mkdir(parents=True)
+    (pack / "0.png").write_bytes(b"x" * 1000)
+
+    unrelated_dir = tmp_path / "My Important Documents"
+    unrelated_dir.mkdir()
+    (unrelated_dir / "keep.txt").write_bytes(b"keep me")
+    loose_file = tmp_path / "notes.txt"
+    loose_file.write_bytes(b"keep me too")
+
+    removed, _ = pf.clear_recordings()
+
+    assert removed == 1
+    assert unrelated_dir.is_dir()
+    assert (unrelated_dir / "keep.txt").exists()
+    assert loose_file.exists()
 
 
 def test_uuid_persisted_at_start_and_stable(tmp_path, monkeypatch):

--- a/tests/test_fight_pack_recorder.py
+++ b/tests/test_fight_pack_recorder.py
@@ -103,6 +103,27 @@ def test_clear_recordings_preserves_unrelated_dirs(tmp_path, monkeypatch):
     assert loose_file.exists()
 
 
+def test_clear_recordings_removes_zip_archives(tmp_path, monkeypatch):
+    """clear_recordings() also drops archived zip bundles so the button reclaims
+    all recording space, and counts their bytes in bytes_freed."""
+    monkeypatch.setattr(pf, "get_recordings_dir", lambda *a, **k: str(tmp_path))
+
+    pack = tmp_path / "20240101-120000-abc123" / "frames"
+    pack.mkdir(parents=True)
+    (pack / "0.png").write_bytes(b"x" * 1000)
+
+    zips_dir = tmp_path / "zips"
+    zips_dir.mkdir()
+    (zips_dir / "packs-a__b.zip").write_bytes(b"z" * 2000)
+
+    removed, freed = pf.clear_recordings()
+
+    assert removed == 1  # only loose packs counted as packs_removed
+    assert freed >= 3000  # 1000 (pack) + 2000 (zip)
+    assert not zips_dir.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_uuid_persisted_at_start_and_stable(tmp_path, monkeypatch):
     monkeypatch.setattr(rec, "get_recordings_dir", lambda *a, **k: str(tmp_path))
 

--- a/tests/test_recording_archiver.py
+++ b/tests/test_recording_archiver.py
@@ -1,0 +1,113 @@
+"""Offline tests for the periodic recording archiver (bundle + crash-safety)."""
+
+import json
+import os
+import shutil
+import zipfile
+
+import pyclashbot.bot.recording_archiver as arch
+import pyclashbot.utils.platform as pf
+
+
+def _make_pack(rec_dir, slug, size_bytes):
+    """Create a slug-named pack folder of roughly size_bytes."""
+    pack = os.path.join(rec_dir, slug)
+    os.makedirs(os.path.join(pack, "frames"), exist_ok=True)
+    with open(os.path.join(pack, "manifest.json"), "w", encoding="utf-8") as f:
+        json.dump({"slug": slug}, f)
+    with open(os.path.join(pack, "frames", "000000.bin"), "wb") as f:
+        f.write(b"\x00" * size_bytes)
+    return pack
+
+
+def _slugs(n):
+    # Chronological slugs (timestamp-ordered) matching recorder._new_slug shape.
+    return [f"2026010{i}-120000-0000{i:02x}" for i in range(1, n + 1)]
+
+
+def test_below_threshold_does_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(arch, "ARCHIVE_THRESHOLD_BYTES", 1000)
+    monkeypatch.setattr(arch, "TARGET_ARCHIVE_BYTES", 1000)
+    rec = str(tmp_path / "recordings")
+    os.makedirs(rec)
+    for slug in _slugs(2):
+        _make_pack(rec, slug, 100)
+
+    assert arch.maybe_archive_recordings(custom_path=rec) is None
+    assert sorted(os.listdir(rec)) == _slugs(2)
+
+
+def test_archives_oldest_without_splitting(tmp_path, monkeypatch):
+    # Use tiny thresholds so the test moves bytes, not gigabytes.
+    monkeypatch.setattr(arch, "ARCHIVE_THRESHOLD_BYTES", 1000)
+    monkeypatch.setattr(arch, "TARGET_ARCHIVE_BYTES", 500)
+    rec = str(tmp_path / "recordings")
+    os.makedirs(rec)
+    slugs = _slugs(4)
+    # 300 B each: total 1200 B > 1000 B threshold; oldest packs gathered until
+    # the 500 B target is reached -> the first two whole packs, never a partial.
+    for slug in slugs:
+        _make_pack(rec, slug, 300)
+
+    zip_path = arch.maybe_archive_recordings(custom_path=rec)
+    assert zip_path is not None and os.path.isfile(zip_path)
+
+    # Oldest two are gone from loose recordings; newest two remain. The "zips"
+    # archive folder now lives inside the recordings dir, so exclude it.
+    assert sorted(n for n in os.listdir(rec) if n != "zips") == slugs[2:]
+    with zipfile.ZipFile(zip_path) as zf:
+        archived = {m.replace("\\", "/").split("/", 1)[0] for m in zf.namelist()}
+    assert archived == set(slugs[:2])
+
+    # Disk accounting includes the zip via the all-locations total.
+    zips_dir = pf.get_recording_zips_dir(custom_path=rec)
+    assert os.path.dirname(zip_path) == zips_dir
+    assert pf.recording_zips_total_bytes(custom_path=rec) == os.path.getsize(zip_path)
+
+
+def test_reconcile_heals_partial_delete_without_duplicating(tmp_path, monkeypatch):
+    """A crash after committing the zip but before deleting all sources must not
+    re-archive the survivor (no dupes). Reconcile now runs on the archive path, so
+    drive the loose packs over the threshold to trigger it; it then finishes the
+    delete instead of re-zipping the survivor."""
+    monkeypatch.setattr(arch, "ARCHIVE_THRESHOLD_BYTES", 100)
+    monkeypatch.setattr(arch, "TARGET_ARCHIVE_BYTES", 100)
+    rec = str(tmp_path / "recordings")
+    zips = pf.get_recording_zips_dir(custom_path=rec)
+    os.makedirs(rec)
+    os.makedirs(zips)
+
+    slugs = _slugs(2)
+    for slug in slugs:
+        _make_pack(rec, slug, 300)  # each well over the 100 B threshold
+
+    # Hand-build a committed archive of both packs, then simulate a crash that
+    # deleted only the first source: the second pack is still loose AND archived.
+    zip_path = os.path.join(zips, f"packs-{slugs[0]}__{slugs[1]}.zip")
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+        for slug in slugs:
+            zf.writestr(f"{slug}/manifest.json", "{}")
+
+    # first delete "succeeded" before the simulated crash
+    shutil.rmtree(os.path.join(rec, slugs[0]))
+
+    before = set(os.listdir(zips))
+    arch.maybe_archive_recordings(custom_path=rec)
+
+    # Survivor reclaimed (no loose packs left besides the "zips" folder), and no
+    # new duplicate zip created.
+    assert [n for n in os.listdir(rec) if n != "zips"] == []
+    assert set(os.listdir(zips)) == before
+
+
+def test_orphan_tmp_is_swept(tmp_path):
+    rec = str(tmp_path / "recordings")
+    zips = pf.get_recording_zips_dir(custom_path=rec)
+    os.makedirs(rec)
+    os.makedirs(zips)
+    orphan = os.path.join(zips, "packs-x__y.zip.tmp")
+    with open(orphan, "wb") as f:
+        f.write(b"partial")
+
+    arch.maybe_archive_recordings(custom_path=rec)
+    assert not os.path.exists(orphan)

--- a/tests/test_recordings_path.py
+++ b/tests/test_recordings_path.py
@@ -1,0 +1,98 @@
+"""Offline tests for recordings-path validation and disk-space helpers."""
+
+import os
+
+import pyclashbot.utils.platform as pf
+
+
+def test_empty_path_uses_default():
+    for value in (None, "", "   "):
+        ok, message = pf.validate_recordings_path(value)
+        assert ok is True
+        assert "default" in message.lower()
+
+
+def test_existing_writable_dir_is_valid(tmp_path):
+    ok, message = pf.validate_recordings_path(str(tmp_path))
+    assert ok is True
+    assert "valid" in message.lower()
+
+
+def test_path_pointing_at_file_is_invalid(tmp_path):
+    file_path = tmp_path / "afile.txt"
+    file_path.write_text("x")
+    ok, message = pf.validate_recordings_path(str(file_path))
+    assert ok is False
+    assert "file" in message.lower()
+
+
+def test_nonexistent_with_writable_ancestor_is_valid(tmp_path):
+    target = tmp_path / "does" / "not" / "exist" / "yet"
+    ok, message = pf.validate_recordings_path(str(target))
+    assert ok is True
+    assert "created" in message.lower()
+
+
+def test_nonexistent_on_missing_root_is_invalid():
+    # A drive/root that does not exist cannot be created.
+    bogus = "Z:\\no\\such\\drive" if os.name == "nt" else "/nonexistent-root-xyz/sub/dir"
+    ok, _ = pf.validate_recordings_path(bogus)
+    assert ok is False
+
+
+def test_drive_free_bytes_returns_positive_for_default():
+    free = pf.recordings_drive_free_bytes(None)
+    assert free is None or free > 0
+
+
+def test_drive_free_bytes_for_custom_existing_dir(tmp_path):
+    free = pf.recordings_drive_free_bytes(str(tmp_path))
+    assert free is not None
+    assert free > 0
+
+
+def _make_pack(parent, slug, size_bytes):
+    frames = parent / slug / "frames"
+    frames.mkdir(parents=True)
+    (frames / "0.png").write_bytes(b"x" * size_bytes)
+
+
+def test_total_bytes_counts_only_slug_packs(tmp_path):
+    _make_pack(tmp_path, "20240101-120000-abc123", 2000)
+    unrelated = tmp_path / "my_notes"
+    unrelated.mkdir()
+    (unrelated / "big.bin").write_bytes(b"y" * 9999)
+
+    total = pf.recordings_total_bytes(custom_path=str(tmp_path))
+    assert total == 2000
+
+
+def test_total_bytes_zero_for_missing_dir(tmp_path):
+    assert pf.recordings_total_bytes(custom_path=str(tmp_path / "nope")) == 0
+
+
+def test_total_all_locations_sums_default_and_custom(tmp_path, monkeypatch):
+    default_dir = tmp_path / "appdata" / "py-clash-bot" / "recordings"
+    custom_dir = tmp_path / "custom"
+    default_dir.mkdir(parents=True)
+    custom_dir.mkdir(parents=True)
+    _make_pack(default_dir, "20240101-120000-aaa111", 1000)
+    _make_pack(custom_dir, "20240102-130000-bbb222", 3000)
+
+    # Point the default recordings dir at our temp appdata location.
+    monkeypatch.setattr(pf, "get_app_data_dir", lambda *a, **k: str(tmp_path / "appdata" / "py-clash-bot"))
+
+    total = pf.recordings_total_bytes_all_locations(custom_path=str(custom_dir))
+    assert total == 4000
+
+
+def test_total_all_locations_no_double_count_when_custom_equals_default(tmp_path, monkeypatch):
+    default_dir = tmp_path / "appdata" / "py-clash-bot" / "recordings"
+    default_dir.mkdir(parents=True)
+    _make_pack(default_dir, "20240101-120000-aaa111", 1000)
+
+    monkeypatch.setattr(pf, "get_app_data_dir", lambda *a, **k: str(tmp_path / "appdata" / "py-clash-bot"))
+
+    # Custom path resolves to the same directory as the default.
+    total = pf.recordings_total_bytes_all_locations(custom_path=str(default_dir))
+    assert total == 1000


### PR DESCRIPTION
## Summary

Adds a user-selectable recording folder to the Data tab, threaded through the full fight/recorder chain. Empty falls back to the default app-data location (now shown in the box). The path is validated live (writable dir / creatable / low-disk) and only surfaces problems, and the recordings drive shows an auto-updating "Recordings using N GB" note (default + custom locations, de-duped).

Also hardens recordings handling and tidies the Data tab UI:
- Clear recordings now deletes only slug-named pack folders, so a custom folder's unrelated content is never touched.
- An invalid custom path skips recording gracefully instead of crashing the fight loop.
- Adds an Upload Recordings button, relabels to View Logs / View Recordings, and lays the four actions out in a 2x2 grid.

## Test plan

- [ ] `make test` — offline suite green (incl. new `tests/test_recordings_path.py`).
- [ ] Set a custom recording folder, run a 1v1 fight, confirm a pack lands there; clear an empty default and confirm unrelated subfolders survive.
- [ ] Point the folder at an invalid/unwritable path and confirm recording is skipped (no crash) and the field shows a red warning.