### PR TITLE
fix(shop): claim free offer via FREE! button when popup appears

### DIFF
--- a/pyclashbot/bot/coords.py
+++ b/pyclashbot/bot/coords.py
@@ -146,6 +146,7 @@ SKIP_WAR_BOOT_BUTTON_COORDS = (208, 601)  # the bottom OK / skip button
 
 # --- Shop / daily free offer ---
 CONFIRM_COLLECT_DAILY_FREE_OFFER_BUTTON_COORDS = (210, 440)
+CONFIRM_FREE_REWARD_PURCHASE_1 = (207, 396)  # green FREE! button on the confirmation popup
 SHOP_PAGE_DEADSPACE_COORD = (10, 280)
 PAGINATE_SHOP_PAGE_BUTTON = (65, 600)
 

--- a/pyclashbot/bot/shop_daily_state.py
+++ b/pyclashbot/bot/shop_daily_state.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from pyclashbot.bot.coords import (
     CONFIRM_COLLECT_DAILY_FREE_OFFER_BUTTON_COORDS,
+    CONFIRM_FREE_REWARD_PURCHASE_1,
     PAGINATE_SHOP_PAGE_BUTTON,
     SHOP_PAGE_DEADSPACE_COORD,
 )
@@ -21,6 +22,7 @@ from pyclashbot.bot.nav import (
     navigate_main_page,
 )
 from pyclashbot.bot.state_detect import (
+    check_for_free_offer_confirmation_condition_1,
     check_if_on_clash_main_menu,
     check_if_on_shop,
 )
@@ -67,7 +69,13 @@ def shop_daily_state(emulator, logger: Logger) -> bool:
     emulator.click(*found)
     time.sleep(2)
 
-    emulator.click(*CONFIRM_COLLECT_DAILY_FREE_OFFER_BUTTON_COORDS)
+    # The offer click usually opens a confirmation popup ("Get Gems? FREE!").
+    # When it does, click its FREE! button; otherwise fall back to the default coord.
+    if check_for_free_offer_confirmation_condition_1(emulator):
+        logger.change_status("Free reward confirmation popup detected, confirming...")
+        emulator.click(*CONFIRM_FREE_REWARD_PURCHASE_1)
+    else:
+        emulator.click(*CONFIRM_COLLECT_DAILY_FREE_OFFER_BUTTON_COORDS)
     time.sleep(2)
 
     emulator.click(*SHOP_PAGE_DEADSPACE_COORD)

--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -562,6 +562,41 @@ def check_if_on_shop(emulator) -> bool:
     return True
 
 
+def check_for_free_offer_confirmation_condition_1(emulator) -> bool:
+    """True if the free-offer confirmation popup is open (e.g. "Get Gems? FREE!").
+
+    Fingerprints the green FREE button, the red close X, and the popup's light
+    border. emulator.screenshot() is BGR, so colors are stored [B, G, R] (the
+    captured values were r,g,b).
+    """
+    iar = emulator.screenshot()
+    pixels = [
+        iar[390][178],
+        iar[387][203],
+        iar[391][241],
+        iar[401][179],
+        iar[407][238],
+        iar[213][343],
+        iar[207][348],
+        iar[253][78],
+        iar[394][316],
+        iar[283][340],
+    ]
+    colors = [
+        [119, 235, 107],
+        [119, 235, 107],
+        [119, 235, 107],
+        [73, 228, 58],
+        [73, 228, 58],
+        [49, 53, 254],
+        [249, 249, 249],
+        [243, 238, 227],
+        [243, 238, 227],
+        [243, 238, 227],
+    ]
+    return all_pixels_are_equal(pixels, colors, 25)
+
+
 def check_if_on_social(emulator) -> bool:
     iar = emulator.screenshot()
     pixels = [


### PR DESCRIPTION
## Summary

The daily free-offer claim clicked a stale coord `(210, 440)` that sat below the popup's `FREE!` button, so on layouts like "Get Gems? FREE!" the reward was never collected and the offer icon survived. Now we detect the confirmation popup and click the real button `(207, 396)`, falling back to the old coord when no popup appears.

## Test plan

- [ ] On an account with the free daily offer available, run the shop-daily job and confirm the reward is collected (offer icon gone afterward).
- [ ] Confirm an account with no free offer still returns to main cleanly.