### PR TITLE
feat(war): handle battle-days-started and final-results popups in war nav

### DIFF
--- a/pyclashbot/bot/coords.py
+++ b/pyclashbot/bot/coords.py
@@ -150,6 +150,7 @@ WAR_DEADSPACE_COORD = (20, 330)
 # that can cover the main menu and intercept navigation to the war page.
 WAR_BOOT_REWARD_COORD = (221, 382)  # the reward-chest "OPEN" button
 SKIP_WAR_BOOT_BUTTON_COORDS = (208, 601)  # the bottom OK / skip button
+CLAN_WAR_FINAL_RESULTS_POPUP_OK_BUTTON = (210, 526)  # OK button on the clan-war final-results popup
 
 # --- Shop / daily free offer ---
 CONFIRM_COLLECT_DAILY_FREE_OFFER_BUTTON_COORDS = (210, 440)

--- a/pyclashbot/bot/nav.py
+++ b/pyclashbot/bot/nav.py
@@ -23,6 +23,7 @@ from pyclashbot.bot.coords import (
     CLAN_CHAT_EXIT_DEADSPACE_COORD,
     CLAN_CHAT_TO_SOCIAL_COORD,
     CLAN_VOYAGE_CLOSE_BUTTON_COORDS,
+    CLAN_WAR_FINAL_RESULTS_POPUP_OK_BUTTON,
     CLASH_MAIN_OPTIONS_BURGER_BUTTON,
     DECK_TABS_REGION,
     DECKS_PAGE_BUTTON_COORDS,
@@ -34,6 +35,8 @@ from pyclashbot.bot.coords import (
 from pyclashbot.bot.coords import CLASH_MAIN_DEADSPACE_COORD as CLASH_MAIN_MENU_DEADSPACE_COORD
 from pyclashbot.bot.find import find_fight_mode_icon, find_post_battle_button
 from pyclashbot.bot.state_detect import (
+    check_for_battle_days_started_popup,
+    check_for_final_results_page,
     check_for_trophy_reward_menu,
     check_if_in_battle,
     check_if_on_battle_log_page,
@@ -482,7 +485,8 @@ def navigate_main_page(emulator, logger: Logger, start_page: str, end_page: str)
         raise ValueError(f"no recorded navigation for {start_page!r} -> {end_page!r}")
 
     logger.log(f"navigate_main_page: {start_page} -> {end_page} via {len(clicks)} click(s)")
-    for x, y in clicks:
+    for i, (x, y) in enumerate(clicks, 1):
+        logger.log(f"  step {i}/{len(clicks)}: clicking ({x}, {y})")
         emulator.click(x, y)
         time.sleep(2)
 
@@ -491,12 +495,35 @@ def navigate_main_page(emulator, logger: Logger, start_page: str, end_page: str)
     # the flash, see the war page (popup not up yet), miss it, and get stuck behind
     # the popup. Then click through it before the destination check.
     if end_page == PAGE_WAR:
+        logger.log("  war page: waiting 5s for the popup to settle")
         time.sleep(5)
+        # Battle-days-started popup FIRST: it fronts the war page before the
+        # final-results / war-boot popups when a new battle day begins.
+        logger.log("  checking for battle-days-started popup...")
+        if check_for_battle_days_started_popup(emulator):
+            logger.change_status("Battle-days-started popup detected, handling it")
+            handle_battle_days_started_popup(emulator, logger)
+        else:
+            logger.log("  no battle-days-started popup")
+        # Final-results check next: it's the more specific fingerprint (magenta title
+        # band), whereas the war-boot check shares the bottom button bar and would
+        # false-positive on the final-results page. Handle the specific one, then war boot.
+        logger.log("  checking for final-results page...")
+        if check_for_final_results_page(emulator):
+            logger.change_status("War final-results page detected, handling it")
+            handle_final_results_page(emulator, logger)
+        else:
+            logger.log("  no final-results page")
+        logger.log("  checking for war-boot popup...")
         if check_if_on_war_boot(emulator):
             logger.change_status("War boot popup detected, handling it")
             handle_war_boot(emulator, logger)
+        else:
+            logger.log("  no war-boot popup")
 
-    return MAIN_PAGE_CHECKS[end_page](emulator)
+    arrived = MAIN_PAGE_CHECKS[end_page](emulator)
+    logger.log(f"  arrival check: on {end_page}? {arrived}")
+    return arrived
 
 
 _WAR_BOOT_HANDLE_TIMEOUT_S = 30.0
@@ -512,6 +539,7 @@ def handle_war_boot(emulator, logger: Logger) -> bool:
     logger.change_status("Handling war boot popup...")
     start_time = time.time()
     while time.time() - start_time < _WAR_BOOT_HANDLE_TIMEOUT_S:
+        logger.log(f"  war-boot: clicking reward at {WAR_BOOT_REWARD_COORD}")
         emulator.click(*WAR_BOOT_REWARD_COORD)
         time.sleep(2)
         if check_if_on_war(emulator):
@@ -519,6 +547,34 @@ def handle_war_boot(emulator, logger: Logger) -> bool:
             return True
     logger.change_status("Timed out handling war boot popup")
     return check_if_on_war(emulator)
+
+
+def handle_final_results_page(emulator, logger: Logger) -> bool:
+    """Clear the clan-war final-results page by clicking its OK button twice.
+
+    Detected by state_detect.check_for_final_results_page after the war boot popup.
+    Two OK clicks (3s apart) dismiss the results popup and any follow-up it raises.
+    """
+    logger.change_status("Handling war final-results page...")
+    for i in range(2):
+        logger.log(f"  final-results: click {i + 1}/2 OK at {CLAN_WAR_FINAL_RESULTS_POPUP_OK_BUTTON}")
+        emulator.click(*CLAN_WAR_FINAL_RESULTS_POPUP_OK_BUTTON)
+        time.sleep(3)
+    return True
+
+
+def handle_battle_days_started_popup(emulator, logger: Logger) -> bool:
+    """Clear the clan-war "battle days started" popup with a single OK click.
+
+    Detected by state_detect.check_for_battle_days_started_popup before the
+    final-results / war-boot checks. Clicks the same button the final-results handler
+    uses (CLAN_WAR_FINAL_RESULTS_POPUP_OK_BUTTON), once.
+    """
+    logger.change_status("Handling battle-days-started popup...")
+    logger.log(f"  battle-days-started: clicking OK at {CLAN_WAR_FINAL_RESULTS_POPUP_OK_BUTTON}")
+    emulator.click(*CLAN_WAR_FINAL_RESULTS_POPUP_OK_BUTTON)
+    time.sleep(3)
+    return True
 
 
 # ===== Card-page / deck-page navigation primitives ===================

--- a/pyclashbot/bot/state_detect.py
+++ b/pyclashbot/bot/state_detect.py
@@ -520,6 +520,70 @@ def check_if_on_card_page(emulator) -> bool:
     if all_pixels_are_equal(pixels, colors3, tol=25):
         return True
 
+    # colors4: an extra card-page fingerprint sampled off VM 2 (a banner layout that
+    # colors1-3 missed) via /show-emulator-image. Clicks are RGB; reversed to BGR here
+    # to match the raw BGR screenshot, same convention as colors1-3.
+    # ponytail: 26 strict-AND landmarks (incl. some anti-alias edges) is brittle — trim
+    # to the stable banner/gray samples if it stops matching a real card page.
+    pixels4 = [
+        iar[58][78],
+        iar[59][93],
+        iar[60][118],
+        iar[60][132],
+        iar[60][141],
+        iar[63][158],
+        iar[65][174],
+        iar[64][186],
+        iar[67][75],
+        iar[67][83],
+        iar[67][92],
+        iar[67][102],
+        iar[72][160],
+        iar[72][172],
+        iar[71][181],
+        iar[72][191],
+        iar[583][97],
+        iar[587][100],
+        iar[594][100],
+        iar[607][98],
+        iar[600][175],
+        iar[596][175],
+        iar[591][177],
+        iar[589][179],
+        iar[587][184],
+        iar[585][191],
+    ]
+    colors4 = [
+        [27, 112, 237],
+        [29, 110, 234],
+        [18, 53, 110],
+        [28, 108, 230],
+        [26, 94, 198],
+        [91, 112, 131],
+        [59, 146, 255],
+        [62, 156, 255],
+        [31, 90, 203],
+        [31, 89, 203],
+        [32, 90, 204],
+        [32, 90, 203],
+        [255, 255, 255],
+        [53, 111, 255],
+        [68, 143, 255],
+        [60, 123, 255],
+        [138, 105, 71],
+        [139, 106, 73],
+        [142, 109, 73],
+        [148, 115, 77],
+        [146, 111, 75],
+        [143, 110, 74],
+        [142, 107, 73],
+        [140, 107, 73],
+        [139, 106, 73],
+        [139, 106, 73],
+    ]
+    if all_pixels_are_equal(pixels4, colors4, tol=25):
+        return True
+
     return False
 
 
@@ -913,6 +977,120 @@ def check_if_on_war_boot(emulator) -> bool:
     """
     iar = emulator.screenshot()
     return _war_boot_pixels_match(iar, _WAR_BOOT_PIXELS) or _war_boot_pixels_match(iar, _WAR_BOOT_PIXELS_ALT)
+
+
+# (x, y, r, g, b) sampled from the clan-war "final results" page that shows up after
+# the war boot popup, during navigation to the war page. Stored RGB just like
+# _WAR_BOOT_PIXELS: _war_boot_pixels_match flips the BGR screenshot to RGB before
+# comparing, and /show-emulator-image clicks are RGB too, so clicked values drop in
+# as-is. Top cluster (y~152) is the magenta title band; bottom cluster (y~600) is the
+# button bar. ponytail: 38 strict-AND pixels with a few anti-alias edges is brittle —
+# trim to the stable title-band samples if it starts false-negativing.
+_FINAL_RESULTS_PAGE_PIXELS: tuple[tuple[int, int, int, int, int], ...] = (
+    (26, 148, 142, 82, 255),
+    (58, 154, 142, 82, 255),
+    (74, 154, 142, 82, 255),
+    (99, 152, 142, 82, 255),
+    (118, 152, 142, 82, 255),
+    (136, 152, 142, 82, 255),
+    (152, 152, 245, 240, 253),
+    (171, 153, 199, 186, 225),
+    (182, 154, 255, 255, 255),
+    (193, 154, 142, 82, 255),
+    (207, 154, 255, 255, 255),
+    (230, 154, 245, 240, 253),
+    (238, 154, 11, 7, 19),
+    (251, 155, 155, 141, 184),
+    (271, 159, 216, 205, 238),
+    (281, 159, 142, 82, 255),
+    (301, 157, 142, 82, 255),
+    (328, 155, 142, 82, 255),
+    (350, 153, 142, 82, 255),
+    (378, 153, 142, 82, 255),
+    (394, 153, 142, 82, 255),
+    (25, 601, 75, 89, 111),
+    (44, 598, 75, 89, 111),
+    (73, 598, 75, 89, 111),
+    (91, 598, 75, 89, 111),
+    (117, 601, 75, 89, 111),
+    (134, 604, 75, 89, 110),
+    (156, 605, 74, 88, 110),
+    (177, 606, 78, 175, 255),
+    (202, 609, 255, 255, 255),
+    (218, 611, 255, 255, 255),
+    (244, 612, 78, 175, 255),
+    (269, 612, 73, 87, 109),
+    (292, 609, 74, 88, 109),
+    (321, 606, 74, 88, 110),
+    (347, 602, 75, 89, 110),
+    (372, 599, 75, 89, 111),
+    (386, 600, 75, 89, 111),
+)
+
+
+def check_for_final_results_page(emulator) -> bool:
+    """True when the clan-war final-results page is covering the screen.
+
+    Checked right after the war boot popup during war-page navigation (see
+    nav.navigate_main_page); cleared by nav.handle_final_results_page.
+    """
+    if not _FINAL_RESULTS_PAGE_PIXELS:
+        return False  # an empty fingerprint would vacuously match every screen
+    iar = emulator.screenshot()
+    return _war_boot_pixels_match(iar, _FINAL_RESULTS_PAGE_PIXELS)
+
+
+# (x, y, r, g, b) sampled from the clan-war "battle days started" popup (shown when a
+# new war battle-day begins), which intercepts navigation to the war page ahead of the
+# final-results / war-boot popups. Stored RGB like _FINAL_RESULTS_PAGE_PIXELS: the
+# matcher flips the BGR screenshot to RGB and /show-emulator-image clicks are RGB, so
+# clicked values drop in as-is.
+_BATTLE_DAYS_STARTED_POPUP_PIXELS: tuple[tuple[int, int, int, int, int], ...] = (
+    (53, 310, 142, 82, 255),
+    (74, 312, 142, 82, 255),
+    (83, 312, 142, 82, 255),
+    (110, 313, 2, 1, 2),
+    (132, 313, 245, 241, 253),
+    (151, 313, 3, 3, 4),
+    (175, 315, 60, 35, 108),
+    (199, 318, 255, 255, 255),
+    (226, 318, 142, 82, 255),
+    (244, 319, 255, 255, 255),
+    (273, 319, 116, 67, 208),
+    (295, 319, 4, 2, 7),
+    (315, 319, 142, 82, 255),
+    (338, 319, 142, 82, 255),
+    (365, 317, 142, 82, 255),
+    (382, 316, 142, 82, 255),
+    (46, 604, 75, 89, 110),
+    (61, 604, 75, 89, 110),
+    (83, 601, 75, 89, 111),
+    (105, 602, 75, 89, 110),
+    (119, 604, 75, 89, 110),
+    (140, 604, 75, 89, 110),
+    (159, 605, 74, 88, 110),
+    (185, 604, 104, 187, 255),
+    (209, 604, 255, 255, 255),
+    (225, 604, 104, 187, 255),
+    (253, 605, 74, 88, 110),
+    (276, 606, 74, 88, 110),
+    (296, 607, 74, 88, 110),
+    (321, 608, 74, 88, 109),
+    (349, 607, 74, 88, 110),
+    (373, 605, 74, 88, 110),
+)
+
+
+def check_for_battle_days_started_popup(emulator) -> bool:
+    """True when the clan-war "battle days started" popup is covering the screen.
+
+    Checked before the final-results and war-boot popups during war-page navigation
+    (see nav.navigate_main_page); cleared by nav.handle_battle_days_started_popup.
+    """
+    if not _BATTLE_DAYS_STARTED_POPUP_PIXELS:
+        return False  # an empty fingerprint would vacuously match every screen
+    iar = emulator.screenshot()
+    return _war_boot_pixels_match(iar, _BATTLE_DAYS_STARTED_POPUP_PIXELS)
 
 
 _WAR_DECK_INDICATOR_TOL = 15


### PR DESCRIPTION
Adds clan-war popup handling to war-page navigation (navigate_main_page), fixing recurring war-nav failures across accounts.

- Detect and dismiss the battle-days-started popup and the final-results page, both checked before the war-boot popup, each with its own detection and OK handler.
- Add a colors4 fingerprint fallback to check_if_on_card_page for a card-page layout the existing palettes missed (fixes war -> card_page navigation).
- Add per-step verbose logging to navigate_main_page.

Verified: full 30-edge nav circuit passes on 10 emulators; CI pre-commit (ruff, ruff-format, ty) green on the Linux mirror.