### PR TITLE
fix(build): restore versioned MSI filename under cx-freeze 8.6

### DIFF
--- a/scripts/setup_msi.py
+++ b/scripts/setup_msi.py
@@ -45,6 +45,10 @@ build_exe_options = {
 bdist_msi_options = {
     "upgrade_code": UPGRADE_CODE,
     "add_to_path": False,
+    # cx-freeze 8.4+ removed bdist_msi's target_version, so without these the
+    # filename/ProductVersion fall back to pyproject's v0.0.0 placeholder.
+    "product_version": VERSION,
+    "output_name": f"pyclashbot-{VERSION}-win64.msi",
     "initial_target_dir": f"[ProgramFilesFolder]\\{PROJECT_NAME}",
     "summary_data": {
         "author": AUTHOR,


### PR DESCRIPTION
## Summary

- Since v3.3.1rc1 every Windows release asset has been uploaded as `pyclashbot-0.0.0-win64.msi`. cx-freeze 8.4+ removed the `bdist_msi` `target_version` option that previously stamped the tag into the filename, and #656's compat fix (stripping `--target-version` from argv) left nothing setting it, so builds fell back to pyproject's `v0.0.0` placeholder.
- Set `output_name` to restore the historical `pyclashbot-<tag>-win64.msi` naming, and `product_version` so the installed MSI carries the real numeric ProductVersion instead of 0.0.0 (which also lets upgrade-code version comparison work).

## Test plan

- [ ] `uv run --group build scripts/setup_msi.py bdist_msi --target-version v9.9.9rc1` produces `dist/pyclashbot-v9.9.9rc1-win64.msi` (verified locally)
- [ ] MSI Property table shows ProductVersion `9.9.9`, not `0.0.0` (verified locally via msilib)
- [ ] Next tag push uploads a correctly named asset