### PR TITLE
fix: properly clear last_three_cards state in fight loop

### DIFF
--- a/pyclashbot/bot/fight.py
+++ b/pyclashbot/bot/fight.py
@@ -528,7 +528,7 @@ def _fight_loop(
     """Method for handling dynamically timed fight"""
     create_default_bridge_iar(emulator)
     _maybe_start_fight_recording(emulator, logger, recording_flag, fight_mode, custom_path)
-    collections.deque(maxlen=3)
+    last_three_cards.clear()
     prev_cards_played = logger.get_cards_played()
     battle_detection_lost_count = 0
 


### PR DESCRIPTION
Hi there!

I noticed a minor bug in fight.py. At the beginning of the _fight_loop, collections.deque(maxlen=3) is called but not assigned to anything. This creates a new deque in memory that is immediately garbage collected, failing to clear the global last_three_cards state from the previous battle.

I changed it to last_three_cards.clear() so the state resets correctly before each new fight.

Thanks for the great project!